### PR TITLE
Updated so that the configurable timeout value is honored on the WinRM call

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Example:
 ```ruby
 Vagrant::Config.run do |config|
 
+  #The following timeout configuration is option, however if have
+  #any large remote_file resources in your chef recipes, you may
+  #experience timeouts (reported as 500 responses)
+  config.winrm.timeout = 1800     #Set WinRM Timeout in seconds (Default 30)
+
   # Configure base box parameters
   config.vm.box = "windows2008r2"
   config.vm.box_url = "./windows-2008-r2.box"

--- a/lib/vagrant-windows/communication/winrm.rb
+++ b/lib/vagrant-windows/communication/winrm.rb
@@ -93,10 +93,12 @@ module Vagrant
           :pass => vm.config.winrm.password,
           :host => vm.config.winrm.host,
           :port => vm.winrm.info[:port],
+          :operation_timeout => vm.config.winrm.timeout,
           :basic_auth_only => true
         }.merge ({})
 
         # create a session
+        logger.info("Attempting WinRM session with options: #{opts}")
         begin
           endpoint = "http://#{opts[:host]}:#{opts[:port]}/wsman"
           client = ::WinRM::WinRMWebService.new(endpoint, :plaintext, opts)


### PR DESCRIPTION
Updated so that the configurable timeout value is honored on the WinRM call. Also adding a section to the example configuration to illustrate how set the configuration value

This is to address https://github.com/BIAINC/vagrant-windows/issues/2. I'll add some more details to the issue itself around my findings and reason for this pull request
