### PR TITLE
Add support for VirtualBox 4.2.x

### DIFF
--- a/lib/vagrant-windows/monkey_patches/driver.rb
+++ b/lib/vagrant-windows/monkey_patches/driver.rb
@@ -5,6 +5,21 @@ require 'vagrant/driver/virtualbox'
 module Vagrant
   module Driver
 
+    class VirtualBox_4_2 < VirtualBoxBase
+      def read_mac_addresses
+        macs = {}
+        info = execute("showvminfo", @uuid, "--machinereadable", :retryable => true)
+        info.split("\n").each do |line|
+          if matcher = /^macaddress(\d+)="(.+?)"$/.match(line)
+            adapter = matcher[1].to_i
+            mac = matcher[2].to_s
+            macs[adapter] = mac
+          end
+        end
+        macs
+      end
+    end
+
     class VirtualBox_4_1 < VirtualBoxBase
       def read_mac_addresses
         macs = {}
@@ -16,7 +31,7 @@ module Vagrant
             macs[adapter] = mac
           end
         end
-        macs 
+        macs
       end
     end
 
@@ -31,7 +46,7 @@ module Vagrant
             macs[adapter] = mac
           end
         end
-        macs 
+        macs
       end
     end
 


### PR DESCRIPTION
A very simple fix... needed to get a multi-vm environment working with VirtualBox 4.2.1 on OS X.
