### PR TITLE
Added puppet support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ What Works?
 ===========
 - vagrant up|hault|reload|provision
 - Chef Vagrant Provisioner
+- Puppet standalone provisioning
 
 What has not been tested
 ========================
 - Everything Else!!!
-- Shell and Puppet Provisioners 
+- Shell provisioning
   - Shell should work, though I have not vetted it yet.
 
 What does not work
@@ -107,3 +108,5 @@ References and Shout Outs
 Changelog
 =========
 0.1.1 - Remove extra debug information from command output.
+0.1.2 - added virtual box 4.2 support
+0.1.3 - added puppet provisioner

--- a/lib/vagrant-windows/provisioners/puppet.rb
+++ b/lib/vagrant-windows/provisioners/puppet.rb
@@ -1,0 +1,46 @@
+module Vagrant
+  	module Provisioners
+    	class Puppet < Base
+    		def run_puppet_client
+		        options = [config.options].flatten
+		        options << "--modulepath '#{@module_paths.values.join(':')}'" if !@module_paths.empty?
+		        options << @manifest_file
+		        options = options.join(" ")
+
+		        # Build up the custom facts if we have any
+		        facter = ""
+		        if !config.facter.empty?
+		          facts = []
+		          config.facter.each do |key, value|
+		            facts << "FACTER_#{key}='#{value}'"
+		          end
+
+		          facter = "#{facts.join(" ")} "
+		        end
+
+		        command = "cd #{manifests_guest_path}; if($?) \{ #{facter}puppet apply #{options} \}"
+
+		        env[:ui].info I18n.t("vagrant.provisioners.puppet.running_puppet",
+		                             :manifest => @manifest_file)
+
+		        env[:vm].channel.sudo(command) do |type, data|
+		          env[:ui].info(data.chomp, :prefix => false)
+		        end
+	    	end
+			def verify_binary(binary)
+	          env[:vm].channel.sudo("command #{binary}",
+	                              :error_class => PuppetError,
+	                              :error_key => :not_detected,
+	                              :binary => binary)
+	        end
+	        def verify_shared_folders(folders)
+		        folders.each do |folder|
+		          @logger.debug("Checking for shared folder: #{folder}")
+		          if !env[:vm].channel.test("if(-not (test-path #{folder})) \{exit 1\} ")
+		            raise PuppetError, :missing_shared_folders
+		          end
+		        end
+	      	end
+     	end
+  	end
+end

--- a/lib/vagrant-windows/provisioners/puppet.rb
+++ b/lib/vagrant-windows/provisioners/puppet.rb
@@ -3,7 +3,12 @@ module Vagrant
     	class Puppet < Base
     		def run_puppet_client
 		        options = [config.options].flatten
-		        options << "--modulepath '#{@module_paths.values.join(':')}'" if !@module_paths.empty?
+		        if env[:vm].config.vm.guest == :windows
+		        	options << "--modulepath '#{@module_paths.values.join(';')}'" if !@module_paths.empty?
+		        else
+		        	options << "--modulepath '#{@module_paths.values.join(':')}'" if !@module_paths.empty?
+		        end
+		        
 		        options << @manifest_file
 		        options = options.join(" ")
 
@@ -17,8 +22,11 @@ module Vagrant
 
 		          facter = "#{facts.join(" ")} "
 		        end
-
-		        command = "cd #{manifests_guest_path}; if($?) \{ #{facter}puppet apply #{options} \}"
+		        if env[:vm].config.vm.guest == :windows
+		        	command = "cd #{manifests_guest_path}; if($?) \{ #{facter}puppet apply #{options} \}"
+		        else
+		        	command = "cd #{manifests_guest_path} && #{facter}puppet apply #{options}"
+		        end
 
 		        env[:ui].info I18n.t("vagrant.provisioners.puppet.running_puppet",
 		                             :manifest => @manifest_file)
@@ -28,7 +36,12 @@ module Vagrant
 		        end
 	    	end
 			def verify_binary(binary)
-	          env[:vm].channel.sudo("command #{binary}",
+			  if env[:vm].config.vm.guest == :windows
+		      	command = "command #{binary}"
+		      else
+		      	command = "which #{binary}"
+		      end
+	          env[:vm].channel.sudo(command,
 	                              :error_class => PuppetError,
 	                              :error_key => :not_detected,
 	                              :binary => binary)
@@ -36,9 +49,18 @@ module Vagrant
 	        def verify_shared_folders(folders)
 		        folders.each do |folder|
 		          @logger.debug("Checking for shared folder: #{folder}")
-		          if !env[:vm].channel.test("if(-not (test-path #{folder})) \{exit 1\} ")
-		            raise PuppetError, :missing_shared_folders
-		          end
+
+		          
+		          if env[:vm].config.vm.guest == :windows
+			       	if !env[:vm].channel.test("if(-not (test-path #{folder})) \{exit 1\} ")
+		            	raise PuppetError, :missing_shared_folders
+		          	end
+			      else
+			       	if !env[:vm].channel.test("test -d #{folder}")
+            			raise PuppetError, :missing_shared_folders
+         			end
+			      end
+
 		        end
 	      	end
      	end

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/vagrant_init.rb
+++ b/lib/vagrant_init.rb
@@ -8,6 +8,9 @@ require 'vagrant-windows/config/winrm'
 # Add WinRM Communication Channel
 require 'vagrant-windows/communication/winrm'
 
+# Add Provisioner
+require 'vagrant-windows/provisioners/puppet'
+
 #Monkey Patch the VM object to support multiple channels
 require 'vagrant-windows/monkey_patches/vm'
 

--- a/vagrant-windows.gemspec
+++ b/vagrant-windows.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = VagrantWindows::VERSION
 
   gem.add_runtime_dependency "winrm", "~> 1.1.1"
-  gem.add_runtime_dependency 'vagrant', "~> 1.0.3"
+  gem.add_runtime_dependency 'vagrant', "~> 1.0"
   gem.add_runtime_dependency 'highline'
 end


### PR DESCRIPTION
bumped version to 0.1.3
changed gem dependencies to allow vagrant 1.0.5 (changed to ~>1.0)

overwrote just enough of the puppet provisioner to allow it to work on
windows.

tested on windows server 2008 R2 datacentre with puppet 3.0.0
