### PR TITLE
Fix Issue 16 - start chef-solo using runas vagrant

### DIFF
--- a/lib/vagrant-windows/scripts/ps_runas.ps1
+++ b/lib/vagrant-windows/scripts/ps_runas.ps1
@@ -1,0 +1,55 @@
+function ps-runas ([String] $user, [String] $password, [String] $cmd, [String] $arguments)
+{
+  $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+
+  $process = New-Object System.Diagnostics.Process
+  $setup = $process.StartInfo
+  $setup.FileName = $cmd
+  $setup.Arguments = $arguments
+  $setup.UserName = $user
+  $setup.Password = $secpasswd
+  $setup.Verb = "runas"
+  $setup.UseShellExecute = $false
+  $setup.RedirectStandardError = $true
+  $setup.RedirectStandardOutput = $true
+  $setup.RedirectStandardInput = $false
+  
+  # Hook into the standard output and error stream events
+  $errEvent = Register-ObjectEvent -InputObj $process `
+  	-Event "ErrorDataReceived" `
+  	-Action `
+  	{
+  		param
+  		(
+  			[System.Object] $sender,
+  			[System.Diagnostics.DataReceivedEventArgs] $e
+  		)
+  		Write-Host $e.Data
+  	}
+  $outEvent = Register-ObjectEvent -InputObj $process `
+  	-Event "OutputDataReceived" `
+  	-Action `
+  	{
+  		param
+  		(
+  			[System.Object] $sender,
+  			[System.Diagnostics.DataReceivedEventArgs] $e
+  		)
+  		Write-Host $e.Data
+  	}
+  
+  if (!$process.Start())
+  {
+    Write-Host "Failed to start $cmd"
+  }
+  
+  $process.BeginOutputReadLine()
+  $process.BeginErrorReadLine()
+  
+  # Wait until process exit
+  $process.WaitForExit()
+  
+  $process.CancelOutputRead()
+  $process.CancelErrorRead()
+  $process.Close()
+}

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
This fixes Issue #16 and allows the SQL Server cookbook to run without error on a Windows vagrant guest.

I added a PowerShell script that creates a System.Diagnostics.Process to ensure the PowerShell process that invokes chef-solo has the ability to delegate credentials to all the sub-processes that the SQL Server setup.exe starts. Essentially all this is doing is calling the Win32 CreateProcessAsUserW with the vagrant username and password to start a new PowerShell process.

vagrant -> winrm -> PowerShell -> ps-runas script -> PowerShell w/cred delegation -> chef-solo -> setup.exe -> setup100.exe etc

I'm not too fond of the "chef-solo -c" check to see if we need to wrap the call in the ps-runas script. I tried wrapping all PowerShell commands in this wrapper, but some fail. I suspect because of the return code or standard output not being the same when run through a sub-process.

Suggestions on how to improve this are welcome.
