### PR TITLE
Dont advice the users to forward the port for RDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Installing Vagrant-Windows
 ==========================
 
@@ -48,7 +47,6 @@ config.vm.guest = :windows
 config.windows.halt_timeout = 15
 config.winrm.username = "vagrant"
 config.winrm.password = "vagrant"
-config.vm.network :forwarded_port, guest: 3389, host: 3389
 config.vm.network :forwarded_port, guest: 5985, host: 5985
 ```
 


### PR DESCRIPTION
... because it breaks VRDE extension of VirtualBox. When you switch on VRDE to be able to connect look on your VM's via RDP viewer, VB offers an according port _on the host_, already. No need to make port forwarding.
