### PR TITLE
Add instruction to reduce delay of WinRM startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All Windows Machines
   - Create a vagrant user, for things to work out of the box username and password should both be "vagrant".
   - Turn off UAC (Msconfig)
   - Disable complex passwords
+  - Optional: Start WinRM a few minutes faster by running: "sc config WinRM start= auto" (default is delayed-auto)
   
 Servers
 --------


### PR DESCRIPTION
In windows 2008 and Windows 7, the WinRM service defaults to start delayed-auto. In my environment this blocks Vagrant for 2.5min. Setting service to start "auto" reduces this delay significantly.
