### PR TITLE
Fix public network setup

### DIFF
--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -1,7 +1,21 @@
+require_relative '../../errors'
+
 module VagrantWindows
   module Guest
     module Cap
       class ConfigureNetworks
+        def self.is_dhcp_enabled(machine, interface_index)
+          cmd = "Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter \"Index=#{interface_index} and DHCPEnabled=True\""
+          # FIXME: this is moronic: if we find any output in the above command,
+          # then we know DHCP is enabled for that interface. This is fragile,
+          # but I have not found a better way of doing this than passing a proc
+          # around
+          has_dhcp_enabled = false
+          block = Proc.new {|type, line| if line; has_dhcp_enabled=true; end}
+          machine.communicate.execute(cmd, nil, &block)
+          return has_dhcp_enabled
+        end
+
         def self.configure_networks(machine, networks)
           driver_mac_address = machine.provider.driver.read_mac_addresses.invert
 
@@ -13,20 +27,26 @@ module VagrantWindows
             naked_mac = nic[:mac_address].gsub(':','')
             if driver_mac_address[naked_mac]
               vm_interface_map[driver_mac_address[naked_mac]] =
-                { :name => nic[:net_connection_id], :mac_address => naked_mac, :index => nic[:interface_index] }
+                { :name => nic[:net_connection_id], :mac_address => naked_mac, :interface_index => nic[:interface_index], :index => nic[:index] }
             end
           end
         
           networks.each do |network|
+            interface_index = vm_interface_map[network[:interface]+1][:index]
+
             netsh = "netsh interface ip set address \"#{vm_interface_map[network[:interface]+1][:name]}\" "
             if network[:type].to_sym == :static
               netsh = "#{netsh} static #{network[:ip]} #{network[:netmask]}"
+              machine.communicate.execute(netsh)
             elsif network[:type].to_sym == :dhcp
-              netsh = "#{netsh} dhcp"
+              # Setting an interface to dhcp if already enabled causes an error
+              if not is_dhcp_enabled(machine, interface_index)
+                netsh = "#{netsh} dhcp"
+                machine.communicate.execute(netsh)
+              end
             else
               raise WindowsError, "#{network[:type]} network type is not supported, try static or dhcp"
             end
-            machine.communicate.execute(netsh)
           end
 
           #netsh interface ip set address name="Local Area Connection" static 192.168.0.100 255.255.255.0 192.168.0.1 1


### PR DESCRIPTION
This fixes an issue where vagrant crashes when up-ing a VM in public network mode: if the network is already set up in dhcp mode, using netsh to set it up to dhcp will return 1, causing a failure in configure_networks.

This PR fixes this by checking whether dhcp is already set up. This also fixes a missing import (the WindowsError exception was undefined).

I am sure there is a better way to do this, but I am rather clueless when it comes to ruby.
