### PR TITLE
Setup work network

### DIFF
--- a/lib/vagrant-windows/config/windows.rb
+++ b/lib/vagrant-windows/config/windows.rb
@@ -6,10 +6,12 @@ module VagrantWindows
 
       attr_accessor :halt_timeout
       attr_accessor :halt_check_interval
+      attr_accessor :set_work_network
       
       def initialize
         @halt_timeout        = UNSET_VALUE
         @halt_check_interval = UNSET_VALUE
+        @set_work_network    = UNSET_VALUE
       end
 
       def validate(machine)
@@ -18,12 +20,14 @@ module VagrantWindows
         errors << "windows.halt_timeout cannot be nil."        if machine.config.windows.halt_timeout.nil?
         errors << "windows.halt_check_interval cannot be nil." if machine.config.windows.halt_check_interval.nil?
 
+        errors << "windows.set_work_network cannot be nil." if machine.config.windows.set_work_network.nil?
         { "Windows Guest" => errors }
       end
 
       def finalize!
         @halt_timeout = 30       if @halt_timeout == UNSET_VALUE
         @halt_check_interval = 1 if @halt_check_interval == UNSET_VALUE
+        @set_work_network = false if @set_work_network == UNSET_VALUE
       end
 
     end

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -54,7 +54,9 @@ module VagrantWindows
             end
           end
 
-          set_networks_to_work(machine)
+          if machine.config.windows.set_work_network
+            set_networks_to_work(machine)
+          end
         end
       end
     end

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -16,6 +16,11 @@ module VagrantWindows
           return has_dhcp_enabled
         end
 
+        def self.set_networks_to_work(machine)
+          command = VagrantWindows.load_script("set_work_network.ps1")
+          machine.communicate.execute(command)
+        end
+
         def self.configure_networks(machine, networks)
           driver_mac_address = machine.provider.driver.read_mac_addresses.invert
 
@@ -49,7 +54,7 @@ module VagrantWindows
             end
           end
 
-          #netsh interface ip set address name="Local Area Connection" static 192.168.0.100 255.255.255.0 192.168.0.1 1
+          set_networks_to_work(machine)
         end
       end
     end

--- a/lib/vagrant-windows/scripts/set_work_network.ps1
+++ b/lib/vagrant-windows/scripts/set_work_network.ps1
@@ -1,0 +1,6 @@
+# Get network connections 
+$networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")) 
+$connections = $networkListManager.GetNetworkConnections() 
+
+# Set network location to Private for all networks 
+$connections | % {$_.GetNetwork().SetCategory(1)}


### PR DESCRIPTION
This small patch add a configuration config.windows.set_work_network (false by default) as a way to solve #63.

If false, nothing changes, if true, every network is automatically setup as a 'work' network. This is the only way I managed to make winrm work on an interface set up as bridged.

I am not sure it is even a good idea, there has to be a way to make winrm works on a public network, but I have not found it yet.
