### PR TITLE
Fixes for Windows Puppet Provisioner on Vagrant 1.2

### DIFF
--- a/lib/vagrant-windows/monkey_patches/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/puppet.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           module_paths = @module_paths.map { |_, to| to }
           if !@module_paths.empty?
             # Prepend the default module path
-            module_paths.unshift("/etc/puppet/modules")
+            module_paths.unshift("/ProgramData/PuppetLabs/puppet/etc/modules")
 
             # Add the command line switch to add the module path
             options << "--modulepath '#{module_paths.join(';')}'"
@@ -63,7 +63,7 @@ module VagrantPlugins
           # Setup the module paths
           @module_paths = []
           @expanded_module_paths.each_with_index do |path, i|
-            @module_paths << [path, File.join(config.pp_path, "modules-#{i}")]
+            @module_paths << [path, File.join(config.temp_dir, "modules-#{i}")]
           end
 
           @logger.debug("Syncing folders from puppet configure")

--- a/lib/vagrant-windows/scripts/command_alias.ps1
+++ b/lib/vagrant-windows/scripts/command_alias.ps1
@@ -16,6 +16,10 @@ function test ([Switch] $d, [String] $path) {
   exit 1
 }
 
+function chmod {
+  exit 0
+}
+
 function chown {
   exit 0
 }


### PR DESCRIPTION
The following patches enable the Puppet provisioner to actually work.  Note that `puppet.bat` needs to be in `%Path%` (but that's required anyways by Vagrant on *NIX systems).
