### PR TITLE
Prevent provisioner output from being garbled

### DIFF
--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -265,13 +265,13 @@ module VagrantWindows
         
         if shell.eql? :cmd
           output = session.cmd(command) do |out, err|
-            handle_out(:stdout, out, &block)
-            handle_out(:stderr, err, &block)
+            block.call(:stdout, out) if block_given? && out
+            block.call(:stderr, err) if block_given? && err
           end
         elsif shell.eql? :powershell
           output = session.powershell(command) do |out, err|
-            handle_out(:stdout, out, &block)
-            handle_out(:stderr, err, &block)
+            block.call(:stdout, out) if block_given? && out
+            block.call(:stderr, err) if block_given? && err
           end
         else
           raise Errors::WinRMInvalidShell, :shell => shell
@@ -284,16 +284,6 @@ module VagrantWindows
         return exit_status
       end
       
-      def handle_out(type, data, &block)
-        if block_given? && data
-          if data =~ /\n/
-            data.split(/\n/).each { |d| block.call(type, d) }
-          else
-            block.call(type, data)
-          end
-        end
-      end
-
     end #WinRM class
   end
 end

--- a/lib/vagrant-windows/monkey_patches/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/chef_solo.rb
@@ -44,9 +44,8 @@ module VagrantPlugins
               # Output the data with the proper color based on the stream.
               color = type == :stdout ? :green : :red
 
-              # Note: Be sure to chomp the data to avoid the newlines that the
-              # Chef outputs.
-              @machine.env.ui.info(data.chomp, :color => color, :prefix => false)
+              @machine.env.ui.info(
+                data, :color => color, :new_line => false, :prefix => false)
             end
 
             # There is no need to run Chef again if it converges

--- a/lib/vagrant-windows/monkey_patches/provisioner.rb
+++ b/lib/vagrant-windows/monkey_patches/provisioner.rb
@@ -42,9 +42,9 @@ module VagrantPlugins
                   # Output the data with the proper color based on the stream.
                   color = type == :stdout ? :green : :red
 
-                  # Note: Be sure to chomp the data to avoid the newlines that the
-                  # Chef outputs.
-                  @machine.env.ui.info(data.chomp, :color => color, :prefix => false)
+                  @machine.ui.info(
+                    data,
+                    :color => color, :new_line => false, :prefix => false)
                 end
               end
               

--- a/lib/vagrant-windows/monkey_patches/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/puppet.rb
@@ -48,8 +48,9 @@ module VagrantPlugins
                                       :manifest => @manifest_file)
 
           @machine.communicate.sudo(command) do |type, data|
-            data.chomp!
-            @machine.env.ui.info(data, :prefix => false) if !data.empty?
+            if !data.empty?
+              @machine.env.ui.info(data, :new_line => false, :prefix => false)
+            end
           end
         end
         


### PR DESCRIPTION
Prevent provisioner output from being garbled in the console when
running on Vagrant version 1.2.5 or higher.  Updated monkey patches to
account for changes that were made in Vagrant regarding provisioner log
output.  (These changes should also be safe to use with vagrant 1.2
versions prior to 1.2.5)
