### PR TITLE
Puppet scheduled task

### DIFF
--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -83,6 +83,7 @@ module VagrantPlugins
               :user => @machine.config.winrm.username,
               :pass => @machine.config.winrm.password,
               :chef_arguments => chef_arguments,
+              :chef_task_name => 'chef-solo',
               :chef_task_xml => win_friendly_path("#{@config.provisioning_path}/cheftask.xml"),
               :chef_task_running => win_friendly_path("#{@config.provisioning_path}/cheftask.running"),
               :chef_task_exitcode => win_friendly_path("#{@config.provisioning_path}/cheftask.exitcode"),
@@ -90,6 +91,7 @@ module VagrantPlugins
               :chef_task_run_ps1 => win_friendly_path("#{@config.provisioning_path}/cheftaskrun.ps1"),
               :chef_stdout_log => win_friendly_path("#{@config.provisioning_path}/chef-solo.log"),
               :chef_stderr_log => win_friendly_path("#{@config.provisioning_path}/chef-solo.err.log"),
+              :chef_env_vars => {},
               :chef_binary_path => win_friendly_path("#{command_env}#{chef_binary_path("chef-solo")}")
             }
           end

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -138,7 +138,7 @@ module VagrantPlugins
               :chef_task_run_ps1 => win_friendly_path("#{@config.temp_dir}/puppettaskrun.ps1"),
               :chef_stdout_log => win_friendly_path("#{@config.temp_dir}/puppet.log"),
               :chef_stderr_log => win_friendly_path("#{@config.temp_dir}/puppet.err.log"),
-              :chef_env_vars => Hash[config.facter.map{|key,val| ["env_#{key}",val] } ],
+              :chef_env_vars => Hash[config.facter.map{|key,val| ["FACTER_#{key}",val] } ],
               :chef_binary_path => win_friendly_path(puppet_bin_location())
             }
           end

--- a/lib/vagrant-windows/scripts/cheftask.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftask.ps1.erb
@@ -1,7 +1,7 @@
-schtasks /query /tn "chef-solo" | Out-Null
+schtasks /query /tn "<%= options[:chef_task_name] %>" | Out-Null
 if ($?) {
   # task already exists, kill it
-  schtasks /delete /tn "chef-solo" /f | Out-Null
+  schtasks /delete /tn "<%= options[:chef_task_name] %>" /f | Out-Null
 }
 
 # Ensure the chef task running file doesn't exist from a previous failure
@@ -10,10 +10,10 @@ if (Test-Path "<%= options[:chef_task_running] %>") {
 }
 
 # schedule the task to run once in the far distant future
-schtasks /create /tn "chef-solo" /xml "<%= options[:chef_task_xml] %>" /ru "<%= options[:user] %>" /rp "<%= options[:pass] %>" | Out-Null
+schtasks /create /tn "<%= options[:chef_task_name] %>" /xml "<%= options[:chef_task_xml] %>" /ru "<%= options[:user] %>" /rp "<%= options[:pass] %>" | Out-Null
 
 # start the scheduled task right now
-schtasks /run /tn "chef-solo" | Out-Null
+schtasks /run /tn "<%= options[:chef_task_name] %>" | Out-Null
 
 # wait for run_chef.ps1 to start or timeout after 1 minute
 $timeoutSeconds = 60

--- a/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
@@ -6,7 +6,7 @@ Try
   "running" | Out-File "<%= options[:chef_task_running] %>"
 
   <% options[:chef_env_vars].each do |key, value| %>
-    <%="$env:FACTER_#{key}='#{value}';"%>
+    <%="$env:#{key}='#{value}';"%>
   <% end %>
 
   $process = (Start-Process "<%= options[:chef_binary_path] %>" -ArgumentList "<%= options[:chef_arguments] %>" -NoNewWindow -PassThru -Wait -RedirectStandardOutput "<%= options[:chef_stdout_log] %>" -RedirectStandardError "<%= options[:chef_stderr_log] %>")

--- a/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
@@ -4,6 +4,11 @@ Set-ExecutionPolicy Unrestricted -force;
 Try
 {
   "running" | Out-File "<%= options[:chef_task_running] %>"
+
+  <% options[:chef_env_vars].each do |key, value| %>
+    <%="$env:FACTER_#{key}='#{value}';"%>
+  <% end %>
+
   $process = (Start-Process "<%= options[:chef_binary_path] %>" -ArgumentList "<%= options[:chef_arguments] %>" -NoNewWindow -PassThru -Wait -RedirectStandardOutput "<%= options[:chef_stdout_log] %>" -RedirectStandardError "<%= options[:chef_stderr_log] %>")
   $exitCode = $process.ExitCode
 }


### PR DESCRIPTION
The existing puppet execution mechanism runs into permissions errors.  Attempting to install Sql Server would result in a security exception in the installer.  This patch fixes the permissions problem by switching puppet to execute using the same scheduled task method as chef.
