### PR TITLE
Fix network configuration

### DIFF
--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -29,13 +29,13 @@ module VagrantWindows
             if network_type == :static
               guest_network.configure_static_interface(
                 interface[:index],
-                interface[:net_connection_id],
+                interface[:name],
                 network[:ip],
                 network[:netmask])
             elsif network_type == :dhcp
               guest_network.configure_dhcp_interface(
                 interface[:index],
-                interface[:net_connection_id])
+                interface[:name])
             else
               raise WindowsError, "#{network_type} network type is not supported, try static or dhcp"
             end


### PR DESCRIPTION
Previously, attempting to configure a second interface (with a static ip address) would result in the following output with VAGRANT_LOG=debug:

```
DEBUG configure_networks: vm_interface_map: {1=>{:name=>"Local Area Connection", :mac_address=>"080027AB52FB", :interface_index=>"12", :index=>"7"}, 2=>{:name=>"Local Area Connection 2", :mac_address=>"08
002753A4C3", :interface_index=>"13", :index=>"8"}}
 INFO winrmshell: Configuring NIC  using static ip 10.20.1.60
DEBUG winrmshell: powershell executing:
netsh interface ip set address "" static 10.20.1.60 255.255.255.0
DEBUG winrmshell: Exit status: 1
```

The issue appears to have been caused by variable name mis-match introduced in some recent changes. With the modifications in this commit, the same debug output now shows (as expected):

```
DEBUG configure_networks: vm_interface_map: {1=>{:name=>"Local Area Connection", :mac_address=>"080027AB52FB", :interface_index=>"12", :index=>"7"}, 2=>{:name=>"Local Area Connection 2", :mac_address=>"08
002753A4C3", :interface_index=>"13", :index=>"8"}}
 INFO winrmshell: Configuring NIC Local Area Connection 2 using static ip 10.20.1.60
DEBUG winrmshell: powershell executing:
netsh interface ip set address "Local Area Connection 2" static 10.20.1.60 255.255.255.0
DEBUG winrmshell: Exit status: 0
```
