### PR TITLE
Fixed netsh cmd silent failure.

### DIFF
--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -53,7 +53,7 @@ module VagrantWindows
             naked_mac = nic[:mac_address].gsub(':','')
             if driver_mac_address[naked_mac]
               vm_interface_map[driver_mac_address[naked_mac]] = {
-                :name => nic[:net_connection_id],
+                :net_connection_id => nic[:net_connection_id],
                 :mac_address => naked_mac,
                 :interface_index => nic[:interface_index],
                 :index => nic[:index] }

--- a/spec/vagrant-windows/guestnetwork_spec.rb
+++ b/spec/vagrant-windows/guestnetwork_spec.rb
@@ -35,8 +35,20 @@ describe VagrantWindows::Communication::GuestNetwork , :integration => true do
     
     it "should configure static IP for adapter" do
       nics = @guestnetwork.network_adapters()
-      @guestnetwork.configure_static_interface(nics[1][:index], nics[1][:net_connection_id], "192.168.0.100", "255.255.255.0")
+      @guestnetwork.configure_static_interface(
+        nics[1][:index],
+        nics[1][:net_connection_id],
+        "192.168.0.121",
+        "255.255.255.0")
+        
       expect(@guestnetwork.is_dhcp_enabled(nics[1][:index])).to be_false
+      
+      # ensure the right IP was set by looking through all the output of ipconfig
+      ipconfig_out = ''
+      @shell.powershell('ipconfig /all') do |_, line|
+        ipconfig_out = ipconfig_out + "#{line}"
+      end
+      expect(ipconfig_out).to include('192.168.0.121')
     end
     
     it "should configure all networks to work mode" do


### PR DESCRIPTION
The netsh command for secondary network adapters was using an emtpy string for the adapter name when running the netsh command causing it to silently fail. This change fixes the cmd so it uses the net_connection_id which contains the proper adapter name, i.e. "Local Area Connection"
