### PR TITLE
ADDED: XP/2003 guest OS support (includes share_name option for config.vm.synced_folder)

### DIFF
--- a/lib/vagrant-windows/guest/cap/mount_shared_folder.rb
+++ b/lib/vagrant-windows/guest/cap/mount_shared_folder.rb
@@ -6,21 +6,23 @@ module VagrantWindows
       class MountSharedFolder
         
         def self.mount_virtualbox_shared_folder(machine, name, guestpath, options)
-          mount_shared_folder(machine, name, guestpath, "\\\\vboxsrv\\")
+          mount_shared_folder(machine, name, guestpath, "\\\\vboxsrv", options)
         end
         
         def self.mount_vmware_shared_folder(machine, name, guestpath, options)
-          mount_shared_folder(machine, name, guestpath, "\\\\vmware-host\\Shared Folders\\")
+          mount_shared_folder(machine, name, guestpath, "\\\\vmware-host\\Shared Folders", options)
         end
         
         protected
         
-        def self.mount_shared_folder(machine, name, guestpath, vm_provider_unc_base)
-          share_name = VagrantWindows::Helper.win_friendly_share_id(name)
+        def self.mount_shared_folder(machine, name, guestpath, share_vm_basepath, options)
+          share_name = options[:share_name] ? options[:share_name] : name
+          share_name = VagrantWindows::Helper.win_friendly_share_id(share_name)
           options = {
             :mount_point => guestpath,
             :share_name => share_name,
-            :vm_provider_unc_path => vm_provider_unc_base + share_name}
+            :share_vm_basepath => share_vm_basepath
+            }
           mount_script = VagrantWindows.load_script_template("mount_volume.ps1", :options => options)
           machine.communicate.execute(mount_script, {:shell => :powershell})
         end

--- a/lib/vagrant-windows/helper.rb
+++ b/lib/vagrant-windows/helper.rb
@@ -15,11 +15,13 @@ module VagrantWindows
     end
 
     # Makes Vagrant share names Windows guest friendly.
-    # Turns '/vagrant' into 'vagrant' or turns ''/a/b/c/d/e' into 'a_b_c_d_e'
+    # Turns '/vagrant' into 'vagrant', '/a/b/c/d/e' into 'a_b_c_d_e', and 'v:' or 'v:/' into 'v'
     #
     # @return [String]
     def win_friendly_share_id(shared_folder_name)
-      return shared_folder_name.gsub(/[\/\/]/,'_').sub(/^_/, '')
+      # replace /, \, and all other reserved windows pathname characters with _; then, cleanup _ groups, and any leading or trailing _'s
+      # URLref: [MSDN - Naming Files, Paths, and Namespaces] http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx @@ http://archive.is/w9ddA @@ http://webcitation.org/6JK50Gyil
+      return shared_folder_name.gsub(/[\/\\<>:"|?*]/,'_').gsub(/__+/,'_').sub(/^_/,'').sub(/_$/,'')
     end
     
     # Checks to see if the specified machine is using VMWare Fusion or Workstation.

--- a/lib/vagrant-windows/monkey_patches/plugins/providers/virtualbox/action/share_folders.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/providers/virtualbox/action/share_folders.rb
@@ -23,7 +23,8 @@ module VagrantPlugins
               hostpath = File.expand_path(data[:hostpath], @env[:root_path])
               hostpath = Vagrant::Util::Platform.cygwin_windows_path(hostpath)
 
-              folder_name = win_friendly_share_id(id.gsub(/[\/\/]/,'_').sub(/^_/, ''))
+              share_name = data[:share_name] ? data[:share_name] : id
+              folder_name = win_friendly_share_id(share_name)
 
               folders << {
                   :name => folder_name,

--- a/lib/vagrant-windows/scripts/command_alias.ps1
+++ b/lib/vagrant-windows/scripts/command_alias.ps1
@@ -1,36 +1,15 @@
-function which {
-    $command = [Array](Get-Command $args[0] -errorAction SilentlyContinue)
-    if($null -eq $command)
-    {
-      exit 1
-    }
-    write-host $command[0].Definition
-    exit 0
-}
-
-function test ([Switch] $d, [String] $path) {
-  if(Test-Path $path)
-  {
-    exit 0
-  }
-  exit 1
-}
-
-function chmod {
-  exit 0
-}
-
-function chown {
-  exit 0
-}
-
-function mkdir ([Switch] $p, [String] $path)
+function which
 {
-  if(Test-Path $path)
-  {
-    exit 0
-  } else {
-    New-Item $path -Type Directory -Force | Out-Null
-  }
+$c=[Array](Get-Command $args[0] -ea 0)
+if($null -eq $c){exit 1}
+write-host $c[0].Definition
+exit 0
 }
-
+function test([Switch]$o,[String]$p)
+{
+if(Test-Path $p){exit 0}
+exit 1
+}
+function chmod{exit 0}
+function chown{exit 0}
+function mkdir([Switch]$o,[String]$p){if(Test-Path $p){exit 0}else{New-Item $p -Type Directory -Force | Out-Null}}

--- a/lib/vagrant-windows/scripts/mount_volume.ps1.erb
+++ b/lib/vagrant-windows/scripts/mount_volume.ps1.erb
@@ -1,50 +1,78 @@
 
+# NOTE: keep this script size small (no more than ~2500 characters [~3000-len(command_alias.ps1]; see https://github.com/WinRb/WinRM/issues/41)
+
 function Test-ReparsePoint([string]$path) {
-  $file = Get-Item $path -Force -ea 0
-  return [bool]($file.Attributes -band [IO.FileAttributes]::ReparsePoint)
+  $f = Get-Item $path -Force -ea 0
+  return [bool]($f.Attributes -band [IO.FileAttributes]::ReparsePoint)
 }
 
+$MP = [System.IO.Path]::GetFullPath("<%= options[:mount_point] %>\.")
+$SN = "<%= options[:share_name] %>"
+$VP = "<%= options[:share_vm_basepath] %>\<%= options[:share_name] %>"
 
-$MountPoint = [System.IO.Path]::GetFullPath("<%= options[:mount_point] %>")
-$ShareName = "<%= options[:share_name] %>"
-$VmProviderUncPath = "<%= options[:vm_provider_unc_path] %>"
+$MP_Drive = Split-Path -qualifier $MP
+$MP_Path = Split-Path -noqualifier $MP
 
-# https://github.com/BIAINC/vagrant-windows/issues/4
-# Not sure why this works, but it does.
+# XP/2003 (Win OS v5.x), no symlinks; Vista+ (Win OS v6+), has symlinks
+$OS_hasSymlinks = ([System.Environment]::OSVersion.Version.Major -gt 5)
 
-& net use $ShareName 2>&1 | Out-Null
+# determine MountPoint information
+$MP_Exists = Test-Path $MP
+$MP_IsSymlink = Test-ReparsePoint $MP
+$MP_IsNetworkDrive = -not (Test-Path "$MP_Drive\") -or ((New-Object System.IO.DriveInfo $MP_Drive).DriveType -eq "Network")
+$MP_IsRootPath = $MP_Path -eq '\'
 
-Write-Debug "Attempting to mount $ShareName to $MountPoint"
-if( (Test-Path "$MountPoint") -and (Test-ReparsePoint "$MountPoint") )
-{
-  Write-Debug "Junction already exists, so I will delete it"
-  # Powershell refuses to delete junctions, oh well use cmd
-  cmd /c rd "$MountPoint"
-
-  if ( $LASTEXITCODE -ne 0 )
+if($MP_IsRootPath -and -not $MP_IsNetworkDrive)
   {
-    Write-Error "Failed to delete symbolic link at $MountPoint"
-    exit 1
+  Write-Error "Mount point drive is not usable; must mount to a mappable network drive (when mounting to a root directory)" 
+  exit 1
+  }
+if(-not $OS_hasSymlinks -and (-not ($MP_IsRootPath -and $MP_IsNetworkDrive)))
+  {
+  Write-Error "VM OS does not have symlinks; must mount share to root folder of a viable network drive"
+  exit 1
   }
 
-} 
-elseif(Test-Path $MountPoint) 
+# fixes enigmatic mounting problem (see https://github.com/BIAINC/vagrant-windows/issues/4)
+net use $SN 2>&1 | Out-Null
+
+Write-Debug "Attempting to mount $SN to $MP"
+if($OS_hasSymlinks -and -not $MP_IsRootPath)
+  {
+  if($MP_Exists -and $MP_IsSymlink)
+    {
+    Write-Debug "Junction already exists, so delete it (using CMD, since Powershell can't handle symlinks correctly)"
+    cmd /c rd "$MP"
+    }
+  elseif($MP_Exists)
+    {
+    Write-Error "Mount point already exists and is not a symbolic link"
+    exit 4
+    }
+
+  $dir = [System.IO.Path]::GetDirectoryName($MP)
+
+  if(-not (Test-Path $dir))
+    {
+    Write-Debug "Creating parent directory for mount point ($dir)"
+    New-Item $dir -Type Directory -Force | Out-Null
+    }
+
+  cmd /c mklink /D "$MP" "$VP" | Out-Null
+  }
+else
+  {
+  if($MP_Exists)
+    {
+    net use $MP_Drive /DELETE 2>&1 | Out-Null
+    }
+  schtasks /DELETE /tn "VAGRANT-Mount-$SN" /f  2>&1 | Out-Null
+  schtasks /CREATE /tn "VAGRANT-Mount-$SN" /tr "cmd /c net use $MP_Drive $VP /PERSISTENT:YES" /ru System /sc ONSTART
+  schtasks /RUN /tn "VAGRANT-Mount-$SN"
+  }
+
+if($LASTEXITCODE -ne 0)
 {
-  Write-Debug "Mount point already exists and is not a symbolic link"
-  exit 1
-}
-
-$BaseDirectory = [System.IO.Path]::GetDirectoryName($MountPoint)
-
-if (-not (Test-Path $BaseDirectory))
-{
-  Write-Debug "Creating parent directory for mount point $BaseDirectory"
-  New-Item $BaseDirectory -Type Directory -Force | Out-Null
-}
-
-cmd /c mklink /D "$MountPoint" "$VmProviderUncPath" | out-null
-
-if ( $LASTEXITCODE -ne 0 )
-{
+  Write-Error "Unspecified error while mounting ($SN)"
   exit 1
 }

--- a/spec/vagrant-windows/mount_shared_folder_spec.rb
+++ b/spec/vagrant-windows/mount_shared_folder_spec.rb
@@ -12,7 +12,7 @@ describe VagrantWindows::Guest::Cap::MountSharedFolder, :unit => true do
   describe "mount_virtualbox_shared_folder" do
     it "should run script with vbox paths"  do
       @communicator.expects(:execute).with do |script, options|
-        expect(script).to include("$VmProviderUncPath = \"\\\\vboxsrv\\vagrant\"")
+        expect(script).to include("$VP = \"\\\\vboxsrv\\vagrant\"")
       end      
 
       VagrantWindows::Guest::Cap::MountSharedFolder.mount_virtualbox_shared_folder(
@@ -23,7 +23,7 @@ describe VagrantWindows::Guest::Cap::MountSharedFolder, :unit => true do
   describe "mount_vmware_shared_folder" do
     it "should run script with vmware paths"  do
       @communicator.expects(:execute).with do |script, options|
-        expect(script).to include("$VmProviderUncPath = \"\\\\vmware-host\\Shared Folders\\vagrant\"")
+        expect(script).to include("$VP = \"\\\\vmware-host\\Shared Folders\\vagrant\"")
       end
       
       VagrantWindows::Guest::Cap::MountSharedFolder.mount_vmware_shared_folder(


### PR DESCRIPTION
I needed to do some testing on XP VMs, and wanted a repeatable environment. So, I took a couple of weekends, learned a little Ruby, learned a little about Vagrant and vagrant-windows, and then hacked together support for XP & 2003. Detailed information about the changes are included below in the commit message. Please excuse any "unusual" Ruby code, as I haven't had the opportunity to learn all the common idioms.

For some initial, rough notes on setting up an XP/2003 VM in VirtualBox for packaging, see https://gist.github.com/rivy/85f2bdf853af7bf267ef. Included within the notes are some pointers for building an XPMode installation, as well.

This is working well for me; I hope it's helpful to the general community.
--
Roy Ivy III
## COMMIT

ADDED: XP/2003 guest OS support (includes share_name option for config.vm.synced_folder, allowing provider share name customization)
### Detailed Changelog

ADDED: XP/2003 guest OS support
ADDED: option 'share_name:' for config.vm.synced_folder (eg, config.vm.synced_folder ".", "v:", share_name: "vagrant"), which allows replacement of the automatically generated provider share name
BUGFIX: corrected "\/\/" bug in win_friendly_share_id() [in helper.rb]
CHANGE: added full complement of windows path/file reserved characters to transform in win_friendly_share_id() [in helper.rb]
CHANGE: condensed command_alias.ps1 to leave more space to other scripts
CHANGE: condensed mount_volume.ps1.erb script
CHANGE: updated the mount script testing spec
### Summary

XP/2003 support was added by through the use of drive mapping to mount network shares, and using scheduled tasks for persistence across reboots. NOTE: this method also works for all other currently supported Windows versions, as well (tested on XP, 2003.x64, & Win7 [though only with a VirtualBox provider]).

win_friendly_share_id() [in helper.rb] was updated & expanded to transform any reserved windows character to an alternative usable in a windows path name (see [MSDN - Naming Files, Paths, and Namespaces]). This was needed to allow the use of a drive ('v:') as a mount point for config.vm.synced_folder.

Since the current WinRM module can't execute scripts longer than about 3000 characters on the guest (see [WinRb/WinRM - ISSUE: Problem with long powershell scripts]), it was necessary to condense both the command_alias.ps1 (prefixed to all scripts) and mount_volume.ps1.erb scripts. command_alias.ps1 was optimized down to ~360 characters (from 508); it's a quite simple script, so removing most of the white space and shrinking variable names still leaves readable code. mount_volume.ps1.erb was also optimized to less than 2500 characters.

Additionally, an option 'share_name:' was added to config.vm.synced_folder to allow replacement of the automatically generated provider share name, so that the usual "\\PROVIDERSHARE\vagrant" could be generated even when using the new drive mapping technique to access the provider share.

An example Vagrantfile for an XP/2003 package is @ https://gist.github.com/rivy/c31c107e57a2bd36c2bf
### REFERENCES

URLref: [MSDN - Naming Files, Paths, and Namespaces] http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx @@ http://archive.is/v9UMV @@ http://webcitation.org/6Jtxa0vn3
URLref: [WinRb/WinRM - ISSUE: Problem with long powershell scripts] https://github.com/WinRb/WinRM/issues/41
