### PR TITLE
Respect Vagrant's Puppet Options

### DIFF
--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -43,6 +43,9 @@ module VagrantPlugins
           end
 
           command = "#{facter} puppet apply #{options}"
+          if config.working_directory
+            command = "cd #{config.working_directory}; if($?) \{ #{command} \}"
+          end
 
           @machine.env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet",
                                       :manifest => @manifest_file)

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -4,19 +4,19 @@ module VagrantPlugins
   module Puppet
     module Provisioner
       class Puppet < Vagrant.plugin("2", :provisioner)
-        
+
         # This patch is needed until Vagrant supports Puppet on Windows guests
         run_puppet_apply_on_linux = instance_method(:run_puppet_apply)
         configure_on_linux = instance_method(:configure)
-        
+
         define_method(:run_puppet_apply) do
           is_windows ? run_puppet_apply_on_windows() : run_puppet_apply_on_linux.bind(self).()
         end
-        
+
         define_method(:configure) do |root_config|
           is_windows ? configure_on_windows(root_config) : configure_on_linux.bind(self).(root_config)
         end
-        
+
         def run_puppet_apply_on_windows
           options = [config.options].flatten
           module_paths = @module_paths.map { |_, to| to }
@@ -41,9 +41,9 @@ module VagrantPlugins
 
             facter = "#{facts.join(" ")} "
           end
-          
+
           command = "cd #{manifests_guest_path}; if($?) \{ #{facter} puppet apply #{options} \}"
-          
+
           @machine.env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet",
                                       :manifest => @manifest_file)
 
@@ -53,7 +53,7 @@ module VagrantPlugins
             end
           end
         end
-        
+
         def configure_on_windows(root_config)
           # Calculate the paths we're going to use based on the environment
           root_path = @machine.env.root_path
@@ -70,7 +70,7 @@ module VagrantPlugins
           @logger.debug("Syncing folders from puppet configure")
           @logger.debug("manifests_guest_path = #{manifests_guest_path}")
           @logger.debug("expanded_manifests_path = #{@expanded_manifests_path}")
-          
+
           # Windows guest volume mounting fails without an "id" specified
           # This hacks around that problem and allows the PS mount script to work
           root_config.vm.synced_folder(

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -28,6 +28,16 @@ module VagrantPlugins
             options << "--modulepath '#{module_paths.join(';')}'"
           end
 
+          if @hiera_config_path
+            options << "--hiera_config=#{@hiera_config_path}"
+          end
+
+          if !@machine.env.ui.is_a?(Vagrant::UI::Colored)
+            options << "--color=false"
+          end
+
+          options << "--manifestdir #{manifests_guest_path}"
+          options << "--detailed-exitcodes"
           options << @manifest_file
           options = options.join(" ")
 

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
             facter = "#{facts.join(" ")} "
           end
 
-          command = "cd #{manifests_guest_path}; if($?) \{ #{facter} puppet apply #{options} \}"
+          command = "#{facter} puppet apply #{options}"
 
           @machine.env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet",
                                       :manifest => @manifest_file)
@@ -59,7 +59,7 @@ module VagrantPlugins
           root_path = @machine.env.root_path
           @expanded_manifests_path = @config.expanded_manifests_path(root_path)
           @expanded_module_paths   = @config.expanded_module_paths(root_path)
-          @manifest_file           = @config.manifest_file
+          @manifest_file           = File.join(manifests_guest_path, @config.manifest_file)
 
           # Setup the module paths
           @module_paths = []


### PR DESCRIPTION
The Puppet provisioner in `vagrant-windows` doesn't respect some options, including `hiera_config_path` and `working_directory`.  This PR adds support for these options, and syncs up the code with what's in Vagrant 1.2.
