### PR TITLE
Fix issue 106

### DIFF
--- a/spec/vagrant-windows/winrmcommunicator_spec.rb
+++ b/spec/vagrant-windows/winrmcommunicator_spec.rb
@@ -11,15 +11,17 @@ describe VagrantWindows::Communication::WinRMCommunicator, :integration => true 
   end
   
   describe "execute" do
-    it "should return 1" do
-      expect(@communicator.execute("exit 1")).to eq(1)
+    it "should return 1 when error_check is false" do
+      expect(@communicator.execute("exit 1", { :error_check => false })).to eq(1)
     end
     
-    it "should return 1 with block" do
-      exit_code = @communicator.sudo("exit 1", {}) do |type, line|
-        puts line
-      end
-      expect(exit_code).to eq(1)
+    it "should raise WinRMExecutionError when error_check is true" do
+      expect { @communicator.execute("exit 1") }.to raise_error(VagrantWindows::Errors::WinRMExecutionError)
+    end
+    
+    it "should raise specified error type when specified and error_check is true" do
+      opts = { :error_class => VagrantWindows::Errors::WinRMInvalidShell }
+      expect { @communicator.execute("exit 1", opts) }.to raise_error(VagrantWindows::Errors::WinRMInvalidShell)
     end
   end
 

--- a/spec/vagrant-windows/winrmshell_spec.rb
+++ b/spec/vagrant-windows/winrmshell_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe VagrantWindows::Communication::WinRMShell, :integration => true do
+  
+  before(:all) do
+    # This test requires you already have a running Windows Server 2008 R2 Vagrant VM
+    # Not ideal, but you have to start somewhere
+    @shell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
+  end
+  
+  describe "powershell" do
+    it "should return exit code of 0" do
+      expect(@shell.powershell("exit 0")[:exitcode]).to eq(0)
+    end
+    
+    it "should return exit code greater than 0" do
+      expect(@shell.powershell("exit 1")[:exitcode]).to eq(1)
+    end
+    
+    it "should return stdout" do
+      result = @shell.powershell("dir") do |type, line|
+        expect(type).to eq(:stdout)
+        expect(line.length).to be > 1  
+      end
+      expect(result[:exitcode]).to eq(0)
+    end
+  end
+  
+  describe "cmd" do
+    it "should return stdout" do
+      result = @shell.cmd("dir") do |type, line|
+        expect(type).to eq(:stdout)
+        expect(line.length).to be > 1  
+      end
+      expect(result[:exitcode]).to eq(0)
+    end
+  end
+ 
+end


### PR DESCRIPTION
To match core Vagrant functionality the execute method was changed to respect the error_check argument and raise an exception when set to true.

This makes some core Vagrant error messages accurate, such as when Vagrant attempts to test if the Puppet executable exists on the guest.
