### PR TITLE
Retry on chef failure

### DIFF
--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
               @machine.env.ui.info I18n.t("vagrant.provisioners.chef.running_solo_again")
             end
 
-            exit_status = @machine.communicate.execute(command) do |type, data|
+            exit_status = @machine.communicate.execute(command, :error_check => false) do |type, data|
               # Output the data with the proper color based on the stream.
               color = type == :stdout ? :green : :red
 

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -17,6 +17,11 @@ module VagrantPlugins
         end
         
         def run_chef_solo_on_windows
+          
+          # This re-establishes our symbolic links if they were created between now and a reboot
+          # Fixes issue #119
+          @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
+          
           # create cheftaskrun.ps1 that the scheduled task will invoke when run
           render_file_and_upload("cheftaskrun.ps1", chef_script_options[:chef_task_run_ps1], :options => chef_script_options)
 

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -18,6 +18,10 @@ module VagrantPlugins
         end
 
         def run_puppet_apply_on_windows
+          
+          # This re-establishes our symbolic links if they were created between now and a reboot
+          @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
+          
           options = [config.options].flatten
           module_paths = @module_paths.map { |_, to| to }
           if !@module_paths.empty?

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
Fixed issue 118 and 119.

Chef-solo provisioner wasn't respecting the attempts configuration parameter and would never retry a chef failure.

Chef-solo and Puppet provisioners now force Windows the "refresh" the guest's symbolic links to network shares. This makes it possible to reboot the box between provisioner blocks without error.
