### PR TITLE
Added reboot provisioner

### DIFF
--- a/lib/vagrant-windows/config/reboot.rb
+++ b/lib/vagrant-windows/config/reboot.rb
@@ -1,0 +1,31 @@
+require "vagrant"
+
+module VagrantWindows
+  module Config
+    class Reboot < Vagrant.plugin("2", :config)
+
+      attr_accessor :timeout
+      attr_accessor :check_interval
+      
+      def initialize
+        @timeout        = UNSET_VALUE
+        @check_interval = UNSET_VALUE
+      end
+
+      def validate(machine)
+        errors = []
+
+        errors << "reboot.timeout cannot be nil."        if @timeout.nil?
+        errors << "reboot.check_interval cannot be nil." if @check_interval.nil?
+
+        { "Reboot" => errors }
+      end
+
+      def finalize!
+        @timeout = 60        if @timeout == UNSET_VALUE
+        @check_interval = 10 if @check_interval == UNSET_VALUE
+      end
+
+    end
+  end
+end

--- a/lib/vagrant-windows/plugin.rb
+++ b/lib/vagrant-windows/plugin.rb
@@ -50,7 +50,17 @@ module VagrantWindows
       require_relative "config/winrm"
       VagrantWindows::Config::WinRM
     end
-
+    
+    config(:reboot, :provisioner) do
+      require_relative "config/reboot"
+      VagrantWindows::Config::Reboot
+    end
+    
+    provisioner(:reboot) do
+      require_relative "provisioners/reboot"
+      VagrantWindows::Provisioners::Reboot
+    end
+    
     guest(:windows) do
       require_relative "guest/windows"
       VagrantWindows::Guest::Windows

--- a/lib/vagrant-windows/provisioners/reboot.rb
+++ b/lib/vagrant-windows/provisioners/reboot.rb
@@ -1,0 +1,51 @@
+require 'log4r'
+
+module VagrantWindows
+  module Provisioners
+    
+    # Simple "provisioner" that supports rebooting a box during a single vagrant up run
+    # This ensures that the box is ready to communicate before continuing
+    class Reboot < Vagrant.plugin("2", :provisioner)
+      
+      def initialize(machine, config)
+        @logger = Log4r::Logger.new("vagrant_windows::provisioners::reboot")
+        super
+      end
+      
+      def configure(root_config)
+      end
+      
+      def provision
+        reboot_guest()
+        wait_until_reboot_completes_or_times_out()
+      end
+      
+      def cleanup
+      end
+      
+      
+      private
+      
+      def reboot_guest()
+        @logger.info('Rebooting guest...')
+        @machine.communicate.execute("Restart-Computer -Force")
+      end
+      
+      def wait_until_reboot_completes_or_times_out()
+        elapsed = 0
+        begin 
+          sleep @config.check_interval
+          elapsed += @config.check_interval
+          @logger.debug("Waiting for reboot, elapsed: #{elapsed} seconds")
+        end until @machine.communicate.ready? || elapsed > @config.timeout
+        
+        if elapsed > @config.timeout
+          @logger.warn('Timed out waiting for reboot, guest may not be ready!')
+        else
+          @logger.info('Reboot complete')
+        end
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
There's no easy and reliable way to run multiple provisioner blocks and reboot between them, as the speed of the guest and host come into play. It would be nice to have a way to reliably force a reboot that then blocks the vagrant process from continuing until the guest has finished rebooting.

This adds a "reboot" provisioner to vagrant-windows. Here's an example [Vagrantfile](https://gist.github.com/sneal/7155901) that makes use of a "reboot" provisioner.

Questions
1. Is this just insane or insanely useful?
2. Is there a better way to do this?
3. If it is useful, does it belong in vagrant-windows?
- this isn't a complete PR, its obviously missing tests
