### PR TITLE
Added reboot check before attempting to provision

### DIFF
--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -35,11 +35,7 @@ module VagrantPlugins
           end
         end
         
-        def run_chef_solo_on_windows
-          # This re-establishes our symbolic links if they were created between now and a reboot
-          # Fixes issue #119
-          @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
-          
+        def run_chef_solo_on_windows          
           # create cheftaskrun.ps1 that the scheduled task will invoke when run
           render_file_and_upload("cheftaskrun.ps1", chef_script_options[:chef_task_run_ps1], :options => chef_script_options)
 
@@ -63,6 +59,10 @@ module VagrantPlugins
             else
               @machine.env.ui.info I18n.t("vagrant.provisioners.chef.running_solo_again")
             end
+            
+            # This re-establishes our symbolic links if they were created between now and a reboot
+            # Fixes issue #119
+            @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
 
             exit_status = @machine.communicate.execute(command, :error_check => false) do |type, data|
               # Output the data with the proper color based on the stream.

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -25,13 +25,10 @@ module VagrantPlugins
         def wait_if_rebooting
           # Check to see if the guest is rebooting, if its rebooting then wait until its ready
           @logger.info('Checking guest reboot status')
-          reboot_detect_script = VagrantWindows.load_script('reboot_detect.ps1')
-          exit_status = @machine.communicate.execute(reboot_detect_script, :error_check => false)
-          if exit_status != 0
-            begin
-              @logger.debug('Guest is rebooting, waiting 10 seconds...')
-              sleep(10)
-            end until @machine.communicate.ready?
+          
+          while is_rebooting?(machine) 
+            @logger.debug('Guest is rebooting, waiting 10 seconds...')
+            sleep(10)
           end
         end
         
@@ -117,7 +114,12 @@ module VagrantPlugins
             }
           end
           @chef_script_options
-        end        
+        end
+        
+        def is_rebooting?(machine)
+          reboot_detect_script = VagrantWindows.load_script('reboot_detect.ps1')
+          @machine.communicate.execute(reboot_detect_script, :error_check => false) != 0
+        end
         
         def is_windows
           @machine.config.vm.guest.eql? :windows

--- a/lib/vagrant-windows/scripts/reboot_detect.ps1
+++ b/lib/vagrant-windows/scripts/reboot_detect.ps1
@@ -1,0 +1,31 @@
+# function to check whether machine is currently shutting down
+function ShuttingDown {
+    [string]$sourceCode = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace VagrantWindows {
+    public static class RemoteManager {
+        private const int SM_SHUTTINGDOWN = 0x2000;
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetSystemMetrics(int Index);
+
+        public static bool Shutdown() {
+            return (0 != GetSystemMetrics(SM_SHUTTINGDOWN));
+        }
+    }
+}
+"@
+    $type = Add-Type -TypeDefinition $sourceCode -PassThru
+    return $type::Shutdown()
+}
+
+if (ShuttingDown) {
+  Write-Host "Shutting Down"
+  exit 1
+}
+else {
+  Write-Host "All good"
+  exit 0
+}

--- a/lib/vagrant-windows/scripts/reboot_detect.ps1
+++ b/lib/vagrant-windows/scripts/reboot_detect.ps1
@@ -22,10 +22,22 @@ namespace VagrantWindows {
 }
 
 if (ShuttingDown) {
-  Write-Host "Shutting Down"
   exit 1
 }
 else {
-  Write-Host "All good"
-  exit 0
+  # see if a reboot is scheduled in the future by trying to schedule a reboot
+  . shutdown.exe -f -r -t 60
+  
+  if ($LASTEXITCODE -eq 1190) {
+    # reboot is already pending
+    exit 2
+  }
+  
+  # Remove the pending reboot we just created above
+  if ($LASTEXITCODE -eq 0) {
+    . shutdown.exe -a
+  }
 }
+
+# no reboot in progress or scheduled
+exit 0

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.3.0.pre.1"
+  VERSION = "1.3.0.pre.2"
 end

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.2.3"
+  VERSION = "1.3.0.pre.1"
 end


### PR DESCRIPTION
If the guest is shutting down don't start the chef provisioning run, wait for the machine to come back up in a ready to communicate state.

This solves the problem where chef provisioning may try to start while the machine is shutting down. Depending on the timing this can lead to the dna.json file not being found or at the very least requiring chef to try another attempt.

As a real world example this fixes our CI build of our VisualStudio cookbook that has 2 provisioning steps
1. Install .NET 4.5 & reboot
2. Install Visual Studio
