### PR TITLE
Vagrant windows 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v1.2.2'
+  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v1.3.5'
   gem "mocha", :require => false
 end

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ These commands assume you're running from a regular command window and not Power
    winrm set winrm/config/service/auth @{Basic="true"}
    sc config WinRM start= auto
 ```
+
+#### Additional WinRM 1.1 Configuration
+
+These additional configuration steps are specific to Windows7 and Windows Server 2008 (WinRM 1.1). For Windows Server 2008 R2 and newer you can ignore this section.
+
+1. Ensure the Windows PowerShell feature is installed
+2. [change the default WinRM port](http://technet.microsoft.com/en-us/library/ff520073(v=ws.10).aspx) - see below or [upgrade to WinRM 2.0](http://www.microsoft.com/en-us/download/details.aspx?id=20430).
+```
+netsh firewall add portopening TCP 5985 "Port 5985"
+winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}
+```
+
 ### Required Windows Services
 
 If you like to turn off optional Windows services you'll need to ensure you leave these services enabled for vagrant-windows to continue to work:

--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -83,14 +83,6 @@ module VagrantWindows
         @logger.warn("Downloading: #{from} to #{to} not supported on Windows guests")
       end
       
-      # Runs a remote WQL query against the VM
-      #
-      # Note: This is not part of the standard Vagrant communicator interface, but
-      # guest capabilities may need to use this.
-      def wql(query)
-        winrmshell.wql(query)
-      end
-      
       def set_winrmshell(winrmshell)
         @winrmshell = winrmshell
       end

--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -90,7 +90,7 @@ module VagrantWindows
         if shell.eql? :cmd
           winrmshell.cmd(command, &block)[:exitcode]
         else
-          command = VagrantWindows.load_script("command_alias.ps1") << "\r\n" << command
+          command = VagrantWindows.load_script("command_alias.ps1") << "\r\n" << command << "\r\nexit $LASTEXITCODE"
           winrmshell.powershell(command, &block)[:exitcode]
         end
       end

--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -14,24 +14,24 @@ module VagrantWindows
       attr_reader :windows_machine
       
       def self.match?(machine)
-        machine.config.vm.guest.eql? :windows
+        VagrantWindows::WindowsMachine.is_windows?(machine)
       end
 
       def initialize(machine)
         @windows_machine = VagrantWindows::WindowsMachine.new(machine)
-        @winrm_finder = WinRMFinder.new(machine)
+        @winrm_finder = WinRMFinder.new(@windows_machine)
         @logger = Log4r::Logger.new("vagrant_windows::communication::winrmcommunicator")
         @logger.debug("initializing WinRMCommunicator")
       end
 
       def ready?
-        logger.debug("Checking whether WinRM is ready...")
+        @logger.debug("Checking whether WinRM is ready...")
 
         Timeout.timeout(@windows_machine.winrm_config.timeout) do
           winrmshell.powershell("hostname")
         end
 
-        logger.info("WinRM is ready!")
+        @logger.info("WinRM is ready!")
         return true
         
       rescue Vagrant::Errors::VagrantError => e

--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -58,24 +58,7 @@ module VagrantWindows
 
       def upload(from, to)
         @logger.debug("Uploading: #{from} to #{to}")
-        file = "winrm-upload-#{rand()}"
-        file_name = (winrmshell.cmd("echo %TEMP%\\#{file}"))[:data][0][:stdout].chomp
-        winrmshell.powershell <<-EOH
-          if(Test-Path #{to})
-          {
-            rm #{to}
-          }
-        EOH
-        Base64.encode64(IO.binread(from)).gsub("\n",'').chars.to_a.each_slice(8000-file_name.size) do |chunk|
-          out = winrmshell.cmd("echo #{chunk.join} >> \"#{file_name}\"")
-        end
-        winrmshell.powershell("mkdir $([System.IO.Path]::GetDirectoryName(\"#{to}\"))")
-        winrmshell.powershell <<-EOH
-          $base64_string = Get-Content \"#{file_name}\"
-          $bytes  = [System.Convert]::FromBase64String($base64_string) 
-          $new_file = [System.IO.Path]::GetFullPath(\"#{to}\")
-          [System.IO.File]::WriteAllBytes($new_file,$bytes)
-        EOH
+        winrmshell.upload(from, to)
       end
       
       def download(from, to=nil)

--- a/lib/vagrant-windows/communication/winrmfinder.rb
+++ b/lib/vagrant-windows/communication/winrmfinder.rb
@@ -18,7 +18,7 @@ module VagrantWindows
       # Raises a Vagrant::Errors::SSHNotReady if WinRM is not responding yet.
       #
       # @return [String] The IP of the Windows machine
-      def find_winrm_host_address
+      def winrm_host_address
         # Get the SSH info for the machine, raise an exception if the
         # provider is saying that the machine is not ready.
         ssh_info = @windows_machine.ssh_info
@@ -33,7 +33,7 @@ module VagrantWindows
       # Finds the IP port of the Windows machine's WinRM service.
       #
       # @return [String] The port of the Windows machine's WinRM service
-      def find_winrm_host_port
+      def winrm_host_port
         expected_guest_port = @windows_machine.winrm_config.guest_port
         @logger.debug("Searching for WinRM port: #{expected_guest_port.inspect}")
 

--- a/lib/vagrant-windows/communication/winrmfinder.rb
+++ b/lib/vagrant-windows/communication/winrmfinder.rb
@@ -13,7 +13,11 @@ module VagrantWindows
         @logger = Log4r::Logger.new("vagrant_windows::communication::winrmfinder")
       end
 
-      def winrm_host_address
+      # Finds the address of the Windows machine.
+      # Raises a Vagrant::Errors::SSHNotReady if WinRM is not responding yet.
+      #
+      # @return [String] The IP of the Windows machine
+      def find_winrm_host_address
         # Get the SSH info for the machine, raise an exception if the
         # provider is saying that SSH is not ready.
         ssh_info = @machine.ssh_info
@@ -22,7 +26,10 @@ module VagrantWindows
         return ssh_info[:host]
       end
       
-      def winrm_host_port
+      # Finds the IP port of the Windows machine's WinRM service.
+      #
+      # @return [String] The port of the Windows machine's WinRM service
+      def find_winrm_host_port
         expected_guest_port = @machine.config.winrm.guest_port
         @logger.debug("Searching for WinRM port: #{expected_guest_port.inspect}")
 

--- a/lib/vagrant-windows/communication/winrmfinder.rb
+++ b/lib/vagrant-windows/communication/winrmfinder.rb
@@ -1,15 +1,16 @@
 require 'log4r'
 require_relative '../errors'
+require_relative '../windows_machine'
 
 module VagrantWindows
   module Communication
     class WinRMFinder
 
       attr_reader :logger
-      attr_reader :machine
+      attr_reader :windows_machine
     
-      def initialize(machine)
-        @machine = machine
+      def initialize(windows_machine)
+        @windows_machine = windows_machine
         @logger = Log4r::Logger.new("vagrant_windows::communication::winrmfinder")
       end
 
@@ -20,7 +21,7 @@ module VagrantWindows
       def find_winrm_host_address
         # Get the SSH info for the machine, raise an exception if the
         # provider is saying that SSH is not ready.
-        ssh_info = @machine.ssh_info
+        ssh_info = @windows_machine.ssh_info
         raise Vagrant::Errors::SSHNotReady if ssh_info.nil?
         @logger.info("WinRM host: #{ssh_info[:host]}")
         return ssh_info[:host]
@@ -30,21 +31,16 @@ module VagrantWindows
       #
       # @return [String] The port of the Windows machine's WinRM service
       def find_winrm_host_port
-        expected_guest_port = @machine.config.winrm.guest_port
+        expected_guest_port = @windows_machine.winrm_config.guest_port
         @logger.debug("Searching for WinRM port: #{expected_guest_port.inspect}")
 
         # Look for the forwarded port only by comparing the guest port
-        begin
-          @machine.provider.driver.read_forwarded_ports.each do |_, _, hostport, guestport|
-            return hostport if guestport == expected_guest_port
-          end
-        rescue NoMethodError => e
-          # VMWare provider doesn't support read_forwarded_ports
-          @logger.debug(e.message)
+        @windows_machine.read_forwarded_ports().each do |_, _, hostport, guestport|
+          return hostport if guestport == expected_guest_port
         end
         
         # We tried, give up and use the configured port as-is
-        @machine.config.winrm.port
+        @windows_machine.winrm_config.port
       end
       
     end

--- a/lib/vagrant-windows/communication/winrmshell_factory.rb
+++ b/lib/vagrant-windows/communication/winrmshell_factory.rb
@@ -22,11 +22,11 @@ module VagrantWindows
       # @return [WinRMShell]
       def create_winrm_shell()
         WinRMShell.new(
-          @winrmfinder.find_winrm_host_address(),
+          @winrmfinder.winrm_host_address(),
           @windows_machine.winrm_config.username,
           @windows_machine.winrm_config.password,
           {
-            :port => @winrmfinder.find_winrm_host_port(),
+            :port => @winrmfinder.winrm_host_port(),
             :timeout_in_seconds => @windows_machine.winrm_config.timeout,
             :max_tries => @windows_machine.winrm_config.max_tries
           })

--- a/lib/vagrant-windows/communication/winrmshell_factory.rb
+++ b/lib/vagrant-windows/communication/winrmshell_factory.rb
@@ -7,9 +7,6 @@ module VagrantWindows
     # Factory class for generating new WinRMShell instances
     class WinRMShellFactory
 
-      attr_reader :winrmfinder
-      attr_reader :windows_machine
-
       # @param [WindowsMachine] The Windows machine instance
       # @param [WinRMFinder] The WinRMFinder instance
       def initialize(windows_machine, winrm_finder)
@@ -22,11 +19,11 @@ module VagrantWindows
       # @return [WinRMShell]
       def create_winrm_shell()
         WinRMShell.new(
-          @winrmfinder.winrm_host_address(),
+          @winrm_finder.winrm_host_address(),
           @windows_machine.winrm_config.username,
           @windows_machine.winrm_config.password,
           {
-            :port => @winrmfinder.winrm_host_port(),
+            :port => @winrm_finder.winrm_host_port(),
             :timeout_in_seconds => @windows_machine.winrm_config.timeout,
             :max_tries => @windows_machine.winrm_config.max_tries
           })

--- a/lib/vagrant-windows/communication/winrmshell_factory.rb
+++ b/lib/vagrant-windows/communication/winrmshell_factory.rb
@@ -1,0 +1,37 @@
+require_relative 'winrmshell'
+require_relative 'winrmfinder'
+
+module VagrantWindows
+  module Communication
+    
+    # Factory class for generating new WinRMShell instances
+    class WinRMShellFactory
+
+      attr_reader :winrmfinder
+      attr_reader :windows_machine
+
+      # @param [WindowsMachine] The Windows machine instance
+      # @param [WinRMFinder] The WinRMFinder instance
+      def initialize(windows_machine, winrm_finder)
+        @windows_machine = windows_machine
+        @winrm_finder = winrm_finder
+      end
+      
+      # Creates a new WinRMShell instance
+      #
+      # @return [WinRMShell]
+      def create_winrm_shell()
+        WinRMShell.new(
+          @winrmfinder.find_winrm_host_address(),
+          @windows_machine.winrm_config.username,
+          @windows_machine.winrm_config.password,
+          {
+            :port => @winrmfinder.find_winrm_host_port(),
+            :timeout_in_seconds => @windows_machine.winrm_config.timeout,
+            :max_tries => @windows_machine.winrm_config.max_tries
+          })
+      end
+      
+    end #WinShell class
+  end
+end

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -17,7 +17,7 @@ module VagrantWindows
           
           windows_machine = VagrantWindows::WindowsMachine.new(machine)
           guest_network = VagrantWindows::Communication::GuestNetwork.new(windows_machine.winrmshell)
-          unless windows_machine.is_vmware() 
+          unless windows_machine.is_vmware?() 
             vm_interface_map = create_vm_interface_map(windows_machine, guest_network)
           end
           

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -3,6 +3,7 @@ require_relative '../../communication/guestnetwork'
 require_relative '../../communication/winrmshell'
 require_relative '../../errors'
 require_relative '../../helper'
+require_relative '../../windows_machine'
 
 module VagrantWindows
   module Guest
@@ -14,8 +15,9 @@ module VagrantWindows
         def self.configure_networks(machine, networks)
           @@logger.debug("networks: #{networks.inspect}")
           
-          guest_network = ::VagrantWindows::Communication::GuestNetwork.new(machine.communicate.winrmshell)
-          unless VagrantWindows::Helper.is_vmware(machine) 
+          windows_machine = VagrantWindows::WindowsMachine.new(machine)
+          guest_network = VagrantWindows::Communication::GuestNetwork.new(machine.communicate.winrmshell)
+          unless windows_machine.is_vmware() 
             vm_interface_map = create_vm_interface_map(machine, guest_network)
           end
           

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -16,9 +16,9 @@ module VagrantWindows
           @@logger.debug("networks: #{networks.inspect}")
           
           windows_machine = VagrantWindows::WindowsMachine.new(machine)
-          guest_network = VagrantWindows::Communication::GuestNetwork.new(machine.communicate.winrmshell)
+          guest_network = VagrantWindows::Communication::GuestNetwork.new(windows_machine.winrmshell)
           unless windows_machine.is_vmware() 
-            vm_interface_map = create_vm_interface_map(machine, guest_network)
+            vm_interface_map = create_vm_interface_map(windows_machine, guest_network)
           end
           
           networks.each do |network|
@@ -42,13 +42,13 @@ module VagrantWindows
               raise WindowsError, "#{network_type} network type is not supported, try static or dhcp"
             end
           end
-          guest_network.set_all_networks_to_work() if machine.config.windows.set_work_network
+          guest_network.set_all_networks_to_work() if windows_machine.windows_config.set_work_network
         end
         
         #{1=>{:name=>"Local Area Connection", :mac_address=>"0800275FAC5B", :interface_index=>"11", :index=>"7"}}
-        def self.create_vm_interface_map(machine, guest_network)
+        def self.create_vm_interface_map(windows_machine, guest_network)
           vm_interface_map = {}
-          driver_mac_address = machine.provider.driver.read_mac_addresses.invert
+          driver_mac_address = windows_machine.read_mac_addresses.invert
           @@logger.debug("mac addresses: #{driver_mac_address.inspect}")
           guest_network.network_adapters().each do |nic|
             @@logger.debug("nic: #{nic.inspect}")

--- a/lib/vagrant-windows/guest/cap/halt.rb
+++ b/lib/vagrant-windows/guest/cap/halt.rb
@@ -3,6 +3,10 @@ module VagrantWindows
     module Cap
       class Halt
         def self.halt(machine)
+          # Fix defect 129, if there's an existing scheduled reboot cancel it so shutdown succeeds
+          machine.communicate.execute("shutdown -a", :error_check => false)
+          
+          # Force shutdown the machine now
           machine.communicate.execute("shutdown /s /t 1 /c \"Vagrant Halt\" /f /d p:4:1")
 
           # Wait until the VM's state is actually powered off. If this doesn't

--- a/lib/vagrant-windows/guest/windows.rb
+++ b/lib/vagrant-windows/guest/windows.rb
@@ -12,11 +12,13 @@ module VagrantWindows
       # Vagrant 1.1.x compatibibility methods
       # Implement the 1.1.x methods and call through to the new 1.2.x capabilities
       
+      attr_reader :windows_machine
       attr_reader :machine
       
       def initialize(machine = nil)
         super(machine) unless machine == nil
         @machine = machine
+        @windows_machine = ::VagrantWindows::WindowsMachine.new(machine)
       end
       
       def change_host_name(name)
@@ -32,7 +34,7 @@ module VagrantWindows
       end
       
       def mount_shared_folder(name, guestpath, options)
-        if VagrantWindows::Helper.is_vmware(@machine) then
+        if @windows_machine.is_vmware() then
           VagrantWindows::Guest::Cap::MountSharedFolder.mount_vmware_shared_folder(
             @machine, name, guestpath, options)
         else

--- a/lib/vagrant-windows/guest/windows.rb
+++ b/lib/vagrant-windows/guest/windows.rb
@@ -34,7 +34,7 @@ module VagrantWindows
       end
       
       def mount_shared_folder(name, guestpath, options)
-        if @windows_machine.is_vmware() then
+        if @windows_machine.is_vmware?() then
           VagrantWindows::Guest::Cap::MountSharedFolder.mount_vmware_shared_folder(
             @machine, name, guestpath, options)
         else

--- a/lib/vagrant-windows/helper.rb
+++ b/lib/vagrant-windows/helper.rb
@@ -21,13 +21,6 @@ module VagrantWindows
     def win_friendly_share_id(shared_folder_name)
       return shared_folder_name.gsub(/[\/\/]/,'_').sub(/^_/, '')
     end
-    
-    # Checks to see if the specified machine is using VMWare Fusion or Workstation.
-    #
-    # @return [Boolean]
-    def is_vmware(machine)
-      machine.provider_name.to_s().start_with?('vmware')
-    end
-    
+
   end
 end

--- a/lib/vagrant-windows/helper.rb
+++ b/lib/vagrant-windows/helper.rb
@@ -2,6 +2,8 @@ module VagrantWindows
   module Helper
     extend self
     
+    @@logger = Log4r::Logger.new("vagrant_windows::helper")
+    
     # Makes a path Windows guest friendly.
     # Turns '/vagrant' into 'c:\vagrant'
     #
@@ -20,6 +22,18 @@ module VagrantWindows
     # @return [String]
     def win_friendly_share_id(shared_folder_name)
       return shared_folder_name.gsub(/[\/\/]/,'_').sub(/^_/, '')
+    end
+    
+    # Check to see if the guest is rebooting, if its rebooting then wait until its ready
+    #
+    # @param [WindowsMachine] The windows machine instance
+    # @param [Int] The time in seconds to wait between checks
+    def wait_if_rebooting(windows_machine, wait_in_seconds=10)
+      @@logger.info('Checking guest reboot status')
+      while windows_machine.is_rebooting? 
+        @@logger.debug('Guest is rebooting, waiting 10 seconds...')
+        sleep(wait_in_seconds)
+      end
     end
 
   end

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -15,12 +15,12 @@ module VagrantPlugins
 
         # This patch is needed until Vagrant supports chef on Windows guests
         define_method(:run_chef_solo) do
-          VagrantWindows::WindowsMachine.is_windows?(@machine) ? run_chef_solo_on_windows() : run_chef_solo_on_linux.bind(self).()
+          is_windows? ? run_chef_solo_on_windows() : run_chef_solo_on_linux.bind(self).()
         end
         
         define_method(:provision) do
           windows_machine = VagrantWindows::WindowsMachine.new(@machine)
-          wait_if_rebooting(windows_machine) if VagrantWindows::WindowsMachine.is_windows?(@machine)
+          wait_if_rebooting(windows_machine) if is_windows?
           provision_on_linux.bind(self).()
         end
         
@@ -106,6 +106,10 @@ module VagrantPlugins
             }
           end
           @chef_script_options
+        end
+        
+        def is_windows?
+          VagrantWindows::WindowsMachine.is_windows?(@machine)
         end
         
       end # ChefSolo class

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -35,11 +35,7 @@ module VagrantPlugins
           end
         end
         
-        def run_chef_solo_on_windows
-          # This re-establishes our symbolic links if they were created between now and a reboot
-          # Fixes issue #119
-          @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
-          
+        def run_chef_solo_on_windows          
           # create cheftaskrun.ps1 that the scheduled task will invoke when run
           render_file_and_upload("cheftaskrun.ps1", chef_script_options[:chef_task_run_ps1], :options => chef_script_options)
 
@@ -63,6 +59,10 @@ module VagrantPlugins
             else
               @machine.env.ui.info I18n.t("vagrant.provisioners.chef.running_solo_again")
             end
+            
+            # This re-establishes our symbolic links if they were created between now and a reboot
+            # Fixes issue #119
+            @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
 
             exit_status = @machine.communicate.execute(command, :error_check => false) do |type, data|
               # Output the data with the proper color based on the stream.

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -25,13 +25,10 @@ module VagrantPlugins
         def wait_if_rebooting
           # Check to see if the guest is rebooting, if its rebooting then wait until its ready
           @logger.info('Checking guest reboot status')
-          reboot_detect_script = VagrantWindows.load_script('reboot_detect.ps1')
-          exit_status = @machine.communicate.execute(reboot_detect_script, :error_check => false)
-          if exit_status != 0
-            begin
-              @logger.debug('Guest is rebooting, waiting 10 seconds...')
-              sleep(10)
-            end until @machine.communicate.ready?
+          
+          while is_rebooting?(machine) 
+            @logger.debug('Guest is rebooting, waiting 10 seconds...')
+            sleep(10)
           end
         end
         
@@ -117,7 +114,12 @@ module VagrantPlugins
             }
           end
           @chef_script_options
-        end        
+        end
+        
+        def is_rebooting?(machine)
+          reboot_detect_script = VagrantWindows.load_script('reboot_detect.ps1')
+          @machine.communicate.execute(reboot_detect_script, :error_check => false) != 0
+        end
         
         def is_windows
           @machine.config.vm.guest.eql? :windows

--- a/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/lib/vagrant-windows/monkey_patches/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
           # This re-establishes our symbolic links if they were created between now and a reboot
           @machine.communicate.execute('& net use a-non-existant-share', :error_check => false)
           
-          options = [config.options].flatten
+          options = [@config.options].flatten
           module_paths = @module_paths.map { |_, to| to }
           if !@module_paths.empty?
             # Prepend the default module path
@@ -59,9 +59,9 @@ module VagrantPlugins
 
           # Build up the custom facts if we have any
           facter = ""
-          if !config.facter.empty?
+          if !@config.facter.empty?
             facts = []
-            config.facter.each do |key, value|
+            @config.facter.each do |key, value|
               facts << "$env:FACTER_#{key}='#{value}';"
             end
 
@@ -69,8 +69,8 @@ module VagrantPlugins
           end
 
           command = "#{facter} puppet apply #{options}"
-          if config.working_directory
-            command = "cd #{config.working_directory}; if($?) \{ #{command} \}"
+          if @config.working_directory
+            command = "cd #{@config.working_directory}; if($?) \{ #{command} \}"
           end
 
           @machine.env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet",
@@ -84,7 +84,7 @@ module VagrantPlugins
           
           # Puppet returns 0 or 2 for success with --detailed-exitcodes
           if ![0,2].include?(exit_status)
-            raise Errors::WinRMExecutionError,
+            raise ::VagrantWindows::Errors::WinRMExecutionError,
               :shell => :powershell,
               :command => command,
               :message => "Puppet failed with an exit code of #{exit_status}"
@@ -101,7 +101,7 @@ module VagrantPlugins
           # Setup the module paths
           @module_paths = []
           @expanded_module_paths.each_with_index do |path, i|
-            @module_paths << [path, File.join(config.temp_dir, "modules-#{i}")]
+            @module_paths << [path, File.join(@config.temp_dir, "modules-#{i}")]
           end
 
           @logger.debug("Syncing folders from puppet configure")

--- a/lib/vagrant-windows/scripts/cheftask.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftask.ps1.erb
@@ -35,11 +35,13 @@ while (Test-Path "<%= options[:chef_task_running] %>") {
     $text = (get-content "<%= options[:chef_stdout_log] %>")
     $numLines = ($text | Measure-Object -line).lines    
     $numLinesToRead = $numLines - $numLinesRead
-  
-    $text | select -first $numLinesToRead -skip $numLinesRead | ForEach {
-      Write-Host "$_"
+    
+    if ($numLinesToRead -gt 0) {
+      $text | select -first $numLinesToRead -skip $numLinesRead | ForEach {
+        Write-Host "$_"
+      }
+      $numLinesRead += $numLinesToRead
     }
-    $numLinesRead += $numLinesToRead
   }
 }
 

--- a/lib/vagrant-windows/scripts/cheftask.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftask.ps1.erb
@@ -1,8 +1,5 @@
-schtasks /query /tn "chef-solo" | Out-Null
-if ($?) {
-  # task already exists, kill it
-  schtasks /delete /tn "chef-solo" /f | Out-Null
-}
+# kill the task so we can recreate it
+schtasks /delete /tn "chef-solo" /f 2>&1 | out-null
 
 # Ensure the chef task running file doesn't exist from a previous failure
 if (Test-Path "<%= options[:chef_task_running] %>") {
@@ -34,14 +31,16 @@ $success = $TRUE
 while (Test-Path "<%= options[:chef_task_running] %>") {
   Start-Sleep -m 100
   
-  $text = (get-content "<%= options[:chef_stdout_log] %>")
-  $numLines = ($text | Measure-Object -line).lines    
-  $numLinesToRead = $numLines - $numLinesRead
+  if (Test-Path "<%= options[:chef_stdout_log] %>") {
+    $text = (get-content "<%= options[:chef_stdout_log] %>")
+    $numLines = ($text | Measure-Object -line).lines    
+    $numLinesToRead = $numLines - $numLinesRead
   
-  $text | select -first $numLinesToRead -skip $numLinesRead | ForEach {
-    Write-Host "$_"
+    $text | select -first $numLinesToRead -skip $numLinesRead | ForEach {
+      Write-Host "$_"
+    }
+    $numLinesRead += $numLinesToRead
   }
-  $numLinesRead += $numLinesToRead
 }
 
 exit Get-Content "<%= options[:chef_task_exitcode] %>"

--- a/lib/vagrant-windows/scripts/cheftask.xml.erb
+++ b/lib/vagrant-windows/scripts/cheftask.xml.erb
@@ -34,7 +34,7 @@
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
     <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
-    <Priority>7</Priority>
+    <Priority>4</Priority>
   </Settings>
   <Actions Context="Author">
     <Exec>

--- a/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
+++ b/lib/vagrant-windows/scripts/cheftaskrun.ps1.erb
@@ -10,7 +10,9 @@ Try
 Finally
 {
   $exitCode | Out-File "<%= options[:chef_task_exitcode] %>"
-  del "<%= options[:chef_task_running] %>"
+  if (Test-Path "<%= options[:chef_task_running] %>") {
+    del "<%= options[:chef_task_running] %>"
+  }
 }
 
 exit $exitCode

--- a/lib/vagrant-windows/scripts/reboot_detect.ps1
+++ b/lib/vagrant-windows/scripts/reboot_detect.ps1
@@ -1,0 +1,31 @@
+# function to check whether machine is currently shutting down
+function ShuttingDown {
+    [string]$sourceCode = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace VagrantWindows {
+    public static class RemoteManager {
+        private const int SM_SHUTTINGDOWN = 0x2000;
+
+        [DllImport("User32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetSystemMetrics(int Index);
+
+        public static bool Shutdown() {
+            return (0 != GetSystemMetrics(SM_SHUTTINGDOWN));
+        }
+    }
+}
+"@
+    $type = Add-Type -TypeDefinition $sourceCode -PassThru
+    return $type::Shutdown()
+}
+
+if (ShuttingDown) {
+  Write-Host "Shutting Down"
+  exit 1
+}
+else {
+  Write-Host "All good"
+  exit 0
+}

--- a/lib/vagrant-windows/scripts/reboot_detect.ps1
+++ b/lib/vagrant-windows/scripts/reboot_detect.ps1
@@ -22,10 +22,22 @@ namespace VagrantWindows {
 }
 
 if (ShuttingDown) {
-  Write-Host "Shutting Down"
   exit 1
 }
 else {
-  Write-Host "All good"
-  exit 0
+  # see if a reboot is scheduled in the future by trying to schedule a reboot
+  . shutdown.exe -f -r -t 60
+  
+  if ($LASTEXITCODE -eq 1190) {
+    # reboot is already pending
+    exit 2
+  }
+  
+  # Remove the pending reboot we just created above
+  if ($LASTEXITCODE -eq 0) {
+    . shutdown.exe -a
+  }
 }
+
+# no reboot in progress or scheduled
+exit 0

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.3.0.pre.1"
+  VERSION = "1.3.0.pre.2"
 end

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.2.3"
+  VERSION = "1.3.0.pre.1"
 end

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.3.0.pre.2"
+  VERSION = "1.3.0.pre.3"
 end

--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.3.0.pre.3"
+  VERSION = "1.3.0"
 end

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -16,6 +16,7 @@ module VagrantWindows
     # @param [Machine] The Vagrant machine object
     def initialize(machine)
       @machine = machine
+      @logger = Log4r::Logger.new("vagrant_windows::windows_machine")
     end
     
     # Checks to see if the machine is using VMWare Fusion or Workstation.
@@ -23,6 +24,14 @@ module VagrantWindows
     # @return [Boolean]
     def is_vmware?()
       @machine.provider_name.to_s().start_with?('vmware')
+    end
+    
+    # Checks to see if the machine is rebooting or has a scheduled reboot.
+    #
+    # @return [Boolean] True if rebooting
+    def is_rebooting?()
+      reboot_detect_script = VagrantWindows.load_script('reboot_detect.ps1')
+      @machine.communicate.execute(reboot_detect_script, :error_check => false) != 0
     end
     
     # Returns the active WinRMShell for the guest.

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -1,0 +1,29 @@
+module VagrantWindows
+  
+  # Provides a wrapper around the Vagrant machine object
+  class WindowsMachine
+    
+    attr_reader :machine
+    
+    # @param [Machine] The Vagrant machine object
+    def initialize(machine)
+      @machine = machine
+    end
+    
+    # Checks to see if the machine is using VMWare Fusion or Workstation.
+    #
+    # @return [Boolean]
+    def is_vmware()
+      @machine.provider_name.to_s().start_with?('vmware')
+    end
+    
+    def windows_config()
+      @machine.config.windows
+    end
+    
+    def winrm_config()
+      @machine.config.winrm
+    end
+    
+  end
+end

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -5,6 +5,14 @@ module VagrantWindows
     
     attr_reader :machine
     
+    # Returns true if the specifed Vagrant machine is a Windows guest, otherwise false.
+    #
+    # @param [Machine] The Vagrant machine object
+    # @return [Boolean]
+    def self.is_windows?(machine)
+      machine.config.vm.guest.eql? :windows
+    end
+    
     # @param [Machine] The Vagrant machine object
     def initialize(machine)
       @machine = machine
@@ -30,6 +38,21 @@ module VagrantWindows
     # @return [Hash]
     def read_mac_addresses()
       @machine.provider.driver.read_mac_addresses
+    end
+    
+    # Returns a list of forwarded ports for a VM.
+    # NOTE: For VMWare this is currently unsupported.
+    #
+    # @return [Array<Array>]
+    def read_forwarded_ports()
+      is_vmware() ? [] : @machine.provider.driver.read_forwarded_ports
+    end
+    
+    # Returns the SSH config for this machine.
+    #
+    # @return [Hash]
+    def ssh_info()
+      @machine.ssh_info
     end
     
     def windows_config()

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -17,6 +17,21 @@ module VagrantWindows
       @machine.provider_name.to_s().start_with?('vmware')
     end
     
+    # Returns the active WinRMShell for the guest.
+    #
+    # @return [WinRMShell]
+    def winrmshell()
+      @machine.communicate.winrmshell
+    end
+
+    # Reads the machine's MAC addresses keyed by interface index.
+    # {1=>"0800273FAC5A", 2=>"08002757E68A"}
+    #
+    # @return [Hash]
+    def read_mac_addresses()
+      @machine.provider.driver.read_mac_addresses
+    end
+    
     def windows_config()
       @machine.config.windows
     end

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -21,7 +21,7 @@ module VagrantWindows
     # Checks to see if the machine is using VMWare Fusion or Workstation.
     #
     # @return [Boolean]
-    def is_vmware()
+    def is_vmware?()
       @machine.provider_name.to_s().start_with?('vmware')
     end
     
@@ -45,7 +45,7 @@ module VagrantWindows
     #
     # @return [Array<Array>]
     def read_forwarded_ports()
-      is_vmware() ? [] : @machine.provider.driver.read_forwarded_ports
+      is_vmware?() ? [] : @machine.provider.driver.read_forwarded_ports
     end
     
     # Returns the SSH config for this machine.

--- a/spec/vagrant-windows/guestnetwork_spec.rb
+++ b/spec/vagrant-windows/guestnetwork_spec.rb
@@ -5,7 +5,7 @@ describe VagrantWindows::Communication::GuestNetwork , :integration => true do
   before(:all) do
     # This test requires you already have a running Windows Server 2008 R2 Vagrant VM
     # Not ideal, but you have to start somewhere
-    @shell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
+    @shell = VagrantWindows::Communication::WinRMShell.new("127.0.0.1", "vagrant", "vagrant")
     @guestnetwork = VagrantWindows::Communication::GuestNetwork.new(@shell)
   end
   

--- a/spec/vagrant-windows/helper_spec.rb
+++ b/spec/vagrant-windows/helper_spec.rb
@@ -35,23 +35,5 @@ describe VagrantWindows::Helper , :unit => true do
     end
 
   end
-  
-  describe "is_vmware" do
-    it "should be true for vmware_fusion" do
-      machine = stub(:provider_name => :vmware_fusion)
-      expect(@dummy.is_vmware(machine)).to be_true
-    end
-    
-    it "should be true for vmware_workstation" do
-      machine = stub(:provider_name => :vmware_workstation)
-      expect(@dummy.is_vmware(machine)).to be_true
-    end
-    
-    it "should be false for virtual_box" do
-      machine = stub(:provider_name => :virtual_box)
-      expect(@dummy.is_vmware(machine)).to be_false
-    end
-
-  end
 
 end

--- a/spec/vagrant-windows/windows_machine_spec.rb
+++ b/spec/vagrant-windows/windows_machine_spec.rb
@@ -22,6 +22,22 @@ describe VagrantWindows::WindowsMachine , :unit => true do
       windows_machine = VagrantWindows::WindowsMachine.new(machine)
       expect(windows_machine.is_vmware()).to be_false
     end
+  end
+  
+  describe "is_windows?" do
+    it "should return true when config vm guest is windows" do
+      vm = stub(:guest => :windows)
+      config = stub(:vm => vm)
+      machine = stub(:config => config)
+      expect(VagrantWindows::WindowsMachine.is_windows?(machine)).to be_true
+    end
+    
+    it "should return false when config vm guest is not windows" do
+      vm = stub(:guest => :ubuntu)
+      config = stub(:vm => vm)
+      machine = stub(:config => config)
+      expect(VagrantWindows::WindowsMachine.is_windows?(machine)).to be_false
+    end
 
   end
 

--- a/spec/vagrant-windows/windows_machine_spec.rb
+++ b/spec/vagrant-windows/windows_machine_spec.rb
@@ -4,23 +4,23 @@ require 'vagrant-windows/windows_machine'
 
 describe VagrantWindows::WindowsMachine , :unit => true do
   
-  describe "is_vmware" do
+  describe "is_vmware?" do
     it "should be true for vmware_fusion" do
       machine = stub(:provider_name => :vmware_fusion)
       windows_machine = VagrantWindows::WindowsMachine.new(machine)
-      expect(windows_machine.is_vmware()).to be_true
+      expect(windows_machine.is_vmware?()).to be_true
     end
     
     it "should be true for vmware_workstation" do
       machine = stub(:provider_name => :vmware_workstation)
       windows_machine = VagrantWindows::WindowsMachine.new(machine)
-      expect(windows_machine.is_vmware()).to be_true
+      expect(windows_machine.is_vmware?()).to be_true
     end
     
     it "should be false for virtual_box" do
       machine = stub(:provider_name => :virtual_box)
       windows_machine = VagrantWindows::WindowsMachine.new(machine)
-      expect(windows_machine.is_vmware()).to be_false
+      expect(windows_machine.is_vmware?()).to be_false
     end
   end
   

--- a/spec/vagrant-windows/windows_machine_spec.rb
+++ b/spec/vagrant-windows/windows_machine_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'mocha/api'
+require 'vagrant-windows/windows_machine'
+
+describe VagrantWindows::WindowsMachine , :unit => true do
+  
+  describe "is_vmware" do
+    it "should be true for vmware_fusion" do
+      machine = stub(:provider_name => :vmware_fusion)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.is_vmware()).to be_true
+    end
+    
+    it "should be true for vmware_workstation" do
+      machine = stub(:provider_name => :vmware_workstation)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.is_vmware()).to be_true
+    end
+    
+    it "should be false for virtual_box" do
+      machine = stub(:provider_name => :virtual_box)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.is_vmware()).to be_false
+    end
+
+  end
+
+end

--- a/spec/vagrant-windows/winrmcommunicator_spec.rb
+++ b/spec/vagrant-windows/winrmcommunicator_spec.rb
@@ -6,7 +6,7 @@ describe VagrantWindows::Communication::WinRMCommunicator, :integration => true 
     # This test requires you already have a running Windows Server 2008 R2 Vagrant VM
     # Not ideal, but you have to start somewhere
     @communicator = VagrantWindows::Communication::WinRMCommunicator.new({})
-    @communicator.winrmshell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
+    @communicator.winrmshell = VagrantWindows::Communication::WinRMShell.new("127.0.0.1", "vagrant", "vagrant")
   end
   
   describe "execute" do

--- a/spec/vagrant-windows/winrmcommunicator_spec.rb
+++ b/spec/vagrant-windows/winrmcommunicator_spec.rb
@@ -21,5 +21,25 @@ describe VagrantWindows::Communication::WinRMCommunicator, :integration => true 
       expect(exit_code).to eq(1)
     end
   end
+  
+  describe "upload" do
+    it "should upload the file and overwrite it if it exists" do
+      test_file = Tempfile.new("uploadtest")
+      IO.write(test_file, "hello world")
+      @communicator.upload(test_file, "c:\\vagrantuploadtest.txt")
+      
+      # ensure we can overwrite
+      IO.write(test_file, "goodbye cruel world")
+      @communicator.upload(test_file, "c:\\vagrantuploadtest.txt")
+      
+      # get the uploaded file's contents to ensure it uploaded properly
+      uploaded_file_content = ''
+      @communicator.execute("cat c:\\vagrantuploadtest.txt", {}) do |type, line|
+        uploaded_file_content = uploaded_file_content + line
+      end
+      
+      expect(uploaded_file_content.chomp).to eq("goodbye cruel world")
+    end
+  end
 
 end

--- a/spec/vagrant-windows/winrmcommunicator_spec.rb
+++ b/spec/vagrant-windows/winrmcommunicator_spec.rb
@@ -5,9 +5,8 @@ describe VagrantWindows::Communication::WinRMCommunicator, :integration => true 
   before(:all) do
     # This test requires you already have a running Windows Server 2008 R2 Vagrant VM
     # Not ideal, but you have to start somewhere
-    @shell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
     @communicator = VagrantWindows::Communication::WinRMCommunicator.new({})
-    @communicator.set_winrmshell(@shell)
+    @communicator.winrmshell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
   end
   
   describe "execute" do

--- a/spec/vagrant-windows/winrmfinder_spec.rb
+++ b/spec/vagrant-windows/winrmfinder_spec.rb
@@ -17,8 +17,7 @@ describe VagrantWindows::Communication::WinRMFinder, :unit => true do
       # setup the winrm config to return nil for the host (i.e. the default)
       winrm_config = VagrantWindows::Config::WinRM.new()
       winrm_config.finalize!()
-      machine_config = stub(:winrm => winrm_config)
-      @machine.stubs(:config).returns(machine_config)
+      @machine.stubs(:winrm_config).returns(winrm_config)
       
       # setup the machine ssh_info to return a 10.0.0.1
       @machine.stubs(:ssh_info).returns({ :host => '10.0.0.1' })
@@ -31,8 +30,7 @@ describe VagrantWindows::Communication::WinRMFinder, :unit => true do
       winrm_config = VagrantWindows::Config::WinRM.new()
       winrm_config.host = '10.0.0.1'
       winrm_config.finalize!()
-      machine_config = stub(:winrm => winrm_config)
-      @machine.stubs(:config).returns(machine_config)
+      @machine.stubs(:winrm_config).returns(winrm_config)
       
       # setup the machine ssh_info to return a 10.0.0.1
       @machine.stubs(:ssh_info).returns({ :host => '127.0.0.1' })

--- a/spec/vagrant-windows/winrmshell_spec.rb
+++ b/spec/vagrant-windows/winrmshell_spec.rb
@@ -5,7 +5,7 @@ describe VagrantWindows::Communication::WinRMShell, :integration => true do
   before(:all) do
     # This test requires you already have a running Windows Server 2008 R2 Vagrant VM
     # Not ideal, but you have to start somewhere
-    @shell = VagrantWindows::Communication::WinRMShell.new("localhost", "vagrant", "vagrant")
+    @shell = VagrantWindows::Communication::WinRMShell.new("127.0.0.1", "vagrant", "vagrant")
   end
   
   describe "powershell" do


### PR DESCRIPTION
New features:
- Better reload/reboot support. Shared folders are re-initialized before provisioners are run so they don't error out after a reload/reboot. Provisioners don't run if a reboot is in progress or imminently scheduled.
- Powershell exit codes are properly returned rather than just being True or False.
- Don't error out a VMware provider if the box has a secondary NIC, just display a warning.
- Abstracted the Vagrant machine object to aid in unit testing - added additional unit tests.

Fixed issues:
- 131
- 130
- 129
- 128
- 127
- 126
- 125
- 119
- 74
