### PR TITLE
Vagrant windows 1.3.1

### DIFF
--- a/lib/vagrant-windows/version.rb
+++ b/lib/vagrant-windows/version.rb
@@ -1,3 +1,3 @@
 module VagrantWindows
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -26,6 +26,13 @@ module VagrantWindows
       @machine.provider_name.to_s().start_with?('vmware')
     end
     
+    # Checks to see if the machine is using Oracle VirtualBox.
+    #
+    # @return [Boolean]
+    def is_virtualbox?()
+      @machine.provider_name.to_s().start_with?('virtualbox')
+    end
+    
     # Checks to see if the machine is rebooting or has a scheduled reboot.
     #
     # @return [Boolean] True if rebooting
@@ -50,11 +57,15 @@ module VagrantWindows
     end
     
     # Returns a list of forwarded ports for a VM.
-    # NOTE: For VMWare this is currently unsupported.
+    # NOTE: Only the VBox provider currently supports this method
     #
     # @return [Array<Array>]
     def read_forwarded_ports()
-      is_vmware?() ? [] : @machine.provider.driver.read_forwarded_ports
+      if is_virtualbox?()
+        @machine.provider.driver.read_forwarded_ports
+      else
+        []
+      end
     end
     
     # Returns the SSH config for this machine.

--- a/spec/vagrant-windows/windows_machine_spec.rb
+++ b/spec/vagrant-windows/windows_machine_spec.rb
@@ -24,6 +24,20 @@ describe VagrantWindows::WindowsMachine , :unit => true do
     end
   end
   
+  describe "is_virtualbox?" do
+    it "should be true for virtualbox" do
+      machine = stub(:provider_name => :virtualbox)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.is_virtualbox?()).to be_true
+    end
+    
+    it "should be false for vmware_workstation" do
+      machine = stub(:provider_name => :vmware_workstation)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.is_virtualbox?()).to be_false
+    end
+  end
+  
   describe "is_windows?" do
     it "should return true when config vm guest is windows" do
       vm = stub(:guest => :windows)
@@ -38,7 +52,14 @@ describe VagrantWindows::WindowsMachine , :unit => true do
       machine = stub(:config => config)
       expect(VagrantWindows::WindowsMachine.is_windows?(machine)).to be_false
     end
-
+  end
+  
+  describe "read_forwarded_ports" do
+    it "should return empty array for vmware provider" do
+      machine = stub(:provider_name => :vmware_fusion)
+      windows_machine = VagrantWindows::WindowsMachine.new(machine)
+      expect(windows_machine.read_forwarded_ports()).to eq([])
+    end
   end
 
 end


### PR DESCRIPTION
Fixed issue 137 and 138

Fixing issue 138 also added support for downloadable shell scripts, i.e.

`config.vm.provision :shell, path: "http://192.168.1.2:8000/test.ps1"`
