### PR TITLE
Compatibility with Parallels provider

### DIFF
--- a/lib/vagrant-windows/guest/cap/mount_shared_folder.rb
+++ b/lib/vagrant-windows/guest/cap/mount_shared_folder.rb
@@ -12,7 +12,11 @@ module VagrantWindows
         def self.mount_vmware_shared_folder(machine, name, guestpath, options)
           mount_shared_folder(machine, name, guestpath, "\\\\vmware-host\\Shared Folders\\")
         end
-        
+
+        def self.mount_parallels_shared_folder(machine, name, guestpath, options)
+          mount_shared_folder(machine, name, guestpath, "\\\\psf\\")
+        end
+
         protected
         
         def self.mount_shared_folder(machine, name, guestpath, vm_provider_unc_base)

--- a/lib/vagrant-windows/guest/windows.rb
+++ b/lib/vagrant-windows/guest/windows.rb
@@ -34,8 +34,11 @@ module VagrantWindows
       end
       
       def mount_shared_folder(name, guestpath, options)
-        if @windows_machine.is_vmware?() then
+        if @windows_machine.is_vmware?
           VagrantWindows::Guest::Cap::MountSharedFolder.mount_vmware_shared_folder(
+            @machine, name, guestpath, options)
+        elsif @windows_machine.is_parallels?
+          VagrantWindows::Guest::Cap::MountSharedFolder.mount_parallels_shared_folder(
             @machine, name, guestpath, options)
         else
           VagrantWindows::Guest::Cap::MountSharedFolder.mount_virtualbox_shared_folder(

--- a/lib/vagrant-windows/plugin.rb
+++ b/lib/vagrant-windows/plugin.rb
@@ -92,7 +92,11 @@ module VagrantWindows
         require_relative "guest/cap/mount_shared_folder"
         VagrantWindows::Guest::Cap::MountSharedFolder
       end
-    
+
+      guest_capability(:windows, :mount_parallels_shared_folder) do
+        require_relative "guest/cap/mount_shared_folder"
+        VagrantWindows::Guest::Cap::MountSharedFolder
+      end
     end
 
     # This initializes the internationalization strings.

--- a/lib/vagrant-windows/windows_machine.rb
+++ b/lib/vagrant-windows/windows_machine.rb
@@ -25,7 +25,14 @@ module VagrantWindows
     def is_vmware?()
       @machine.provider_name.to_s().start_with?('vmware')
     end
-    
+
+    # Checks to see if the machine is using Parallels Desktop.
+    #
+    # @return [Boolean]
+    def is_parallels?()
+      @machine.provider_name.to_s().start_with?('parallels')
+    end
+
     # Checks to see if the machine is using Oracle VirtualBox.
     #
     # @return [Boolean]


### PR DESCRIPTION
This commit adds compatibility with [Parallels provider](https://github.com/yshahin/vagrant-parallels)
I've checked it by myself and all existing features is working fine for this environment:
- Vagrant 1.4.0
- 'vagrant-parallels' v0.1.0
- Parallels Desktop 8 and 9
- Host: OS X 10.9
- Guest: Windows Server 2012 R2

P.s. I'm ready to support this compatibility in future.
