### PR TITLE
support for downloading

### DIFF
--- a/lib/vagrant-windows/communication/winrmcommunicator.rb
+++ b/lib/vagrant-windows/communication/winrmcommunicator.rb
@@ -75,8 +75,9 @@ module VagrantWindows
         winrmshell.upload(from, to)
       end
       
-      def download(from, to=nil)
-        @logger.warn("Downloading: #{from} to #{to} not supported on Windows guests")
+      def download(from, to)
+        @logger.debug("Downloading: #{from} to #{to}")
+        winrmshell.download(from, to)
       end
       
       def winrmshell=(winrmshell)

--- a/lib/vagrant-windows/communication/winrmshell.rb
+++ b/lib/vagrant-windows/communication/winrmshell.rb
@@ -77,6 +77,14 @@ module VagrantWindows
         EOH
       end
 
+      def download(from, to)
+        @logger.debug("Downloading: #{from} to #{to}")
+        output = powershell("[System.convert]::ToBase64String([System.IO.File]::ReadAllBytes(\"#{from}\"))")
+        contents = output[:data].map!{|line| line[:stdout]}.join.gsub("\\n\\r", '')
+        out = Base64.decode64(contents)
+        IO.binwrite(to, out)
+      end
+
       protected
       
       def execute_shell(command, shell=:powershell, &block)


### PR DESCRIPTION
Downloading support is required to support **vagrant hostmanager** with Windows guests.  This is sufficient in my tests.

Let me know if there's anything I can do to help get it integrated.  

Thanks!!!
