### PR TITLE
Corrected issue with invalid NICs being returned.

### DIFF
--- a/lib/vagrant-windows/scripts/winrs_v3_get_adapters.ps1
+++ b/lib/vagrant-windows/scripts/winrs_v3_get_adapters.ps1
@@ -1,4 +1,4 @@
-$adapters = get-ciminstance win32_networkadapter -filter "macaddress is not null" 
+$adapters = get-ciminstance win32_networkadapter -filter "macaddress is not null and netconnectionid is not null" 
 $processed = @()
 foreach ($adapter in $adapters) {
   $Processed += new-object PSObject -Property @{


### PR DESCRIPTION
Found an issue with invalid network adapters being returned from the winrs_v3_get_adapters.ps1 script.  The invalid adapters shared the same MAC addresses as valid adapters but their netconnectionid was Nil.
