### PR TITLE
Communicator support for wql

### DIFF
--- a/lib/vagrant-windows/communication/guestnetwork.rb
+++ b/lib/vagrant-windows/communication/guestnetwork.rb
@@ -30,13 +30,13 @@ module VagrantWindows
       #
       # @return [Boolean]
       def is_dhcp_enabled(nic_index)
-        has_dhcp_enabled = false
-        cmd = "Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter \"Index=#{nic_index} and DHCPEnabled=True\""
-        @communicator.execute(cmd) do |type, line|
-          has_dhcp_enabled = !line.nil?
-        end
-        @logger.debug("NIC #{nic_index} has DHCP enabled: #{has_dhcp_enabled}")
-        has_dhcp_enabled
+        cmd = <<-EOH
+          if (Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "Index=#{nic_index} and DHCPEnabled=True") {
+            exit 0
+          }
+          exit 1
+        EOH
+        @communicator.test(cmd)
       end
       
       # Configures the specified interface for DHCP

--- a/lib/vagrant-windows/communication/guestnetwork.rb
+++ b/lib/vagrant-windows/communication/guestnetwork.rb
@@ -12,13 +12,10 @@ module VagrantWindows
       PS_GET_WSMAN_VER = '((test-wsman).productversion.split(" ") | select -last 1).split("\.")[0]'
       WQL_NET_ADAPTERS_V2 = 'SELECT * FROM Win32_NetworkAdapter WHERE MACAddress IS NOT NULL'
 
-      attr_reader :logger
-      attr_reader :winrmshell
-
-      def initialize(winrmshell)
-        @logger = Log4r::Logger.new("vagrant_windows::communication::winrmshell")
+      def initialize(communicator)
+        @logger = Log4r::Logger.new("vagrant_windows::communication::guestnetwork")
         @logger.debug("initializing WinRMShell")
-        @winrmshell = winrmshell
+        @communicator = communicator
       end
       
       # Returns an array of all NICs on the guest. Each array entry is a
@@ -35,7 +32,7 @@ module VagrantWindows
       def is_dhcp_enabled(nic_index)
         has_dhcp_enabled = false
         cmd = "Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter \"Index=#{nic_index} and DHCPEnabled=True\""
-        @winrmshell.powershell(cmd) do |type, line|
+        @communicator.execute(cmd) do |type, line|
           has_dhcp_enabled = !line.nil?
         end
         @logger.debug("NIC #{nic_index} has DHCP enabled: #{has_dhcp_enabled}")
@@ -50,7 +47,7 @@ module VagrantWindows
         @logger.info("Configuring NIC #{net_connection_id} for DHCP")
         if !is_dhcp_enabled(nic_index)
           netsh = "netsh interface ip set address \"#{net_connection_id}\" dhcp"
-          @winrmshell.powershell(netsh)
+          @communicator.execute(netsh)
         end
       end
       
@@ -64,7 +61,7 @@ module VagrantWindows
         @logger.info("Configuring NIC #{net_connection_id} using static ip #{ip}")
         #netsh interface ip set address "Local Area Connection 2" static 192.168.33.10 255.255.255.0
         netsh = "netsh interface ip set address \"#{net_connection_id}\" static #{ip} #{netmask}"
-        @winrmshell.powershell(netsh)
+        @communicator.execute(netsh)
       end
       
       # Sets all networks on the guest to 'Work Network' mode. This is
@@ -73,7 +70,7 @@ module VagrantWindows
       def set_all_networks_to_work()
         @logger.info("Setting all networks to 'Work Network'")
         command = VagrantWindows.load_script("set_work_network.ps1")
-        @winrmshell.powershell(command)
+        @communicator.execute(command)
       end
       
 
@@ -86,7 +83,7 @@ module VagrantWindows
       def wsman_version()
         @logger.debug("querying WSMan version")
         version = ''
-        @winrmshell.powershell(PS_GET_WSMAN_VER) do |type, line|
+        @communicator.execute(PS_GET_WSMAN_VER) do |type, line|
           version = version + "#{line}" if type == :stdout && !line.nil?
         end
         @logger.debug("wsman version: #{version}")
@@ -102,7 +99,7 @@ module VagrantWindows
         @logger.debug("querying network adapters")
         # Get all NICs that have a MAC address
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394216(v=vs.85).aspx
-        adapters = @winrmshell.wql(WQL_NET_ADAPTERS_V2)[:win32_network_adapter]
+        adapters = @communicator.execute(WQL_NET_ADAPTERS_V2, { :shell => :wql } )[:win32_network_adapter]
         @logger.debug("#{adapters.inspect}")
         return adapters
       end
@@ -117,7 +114,7 @@ module VagrantWindows
       def network_adapters_v3_winrm()
         winrs_v3_get_adapters_ps1 = VagrantWindows.load_script("winrs_v3_get_adapters.ps1")
         output = ''
-        @winrmshell.powershell(winrs_v3_get_adapters_ps1) do |type, line|
+        @communicator.execute(winrs_v3_get_adapters_ps1) do |type, line|
           output = output + "#{line}" if type == :stdout && !line.nil?
         end
         adapters = []

--- a/lib/vagrant-windows/guest/cap/configure_networks.rb
+++ b/lib/vagrant-windows/guest/cap/configure_networks.rb
@@ -16,7 +16,7 @@ module VagrantWindows
           @@logger.debug("networks: #{networks.inspect}")
           
           windows_machine = VagrantWindows::WindowsMachine.new(machine)
-          guest_network = VagrantWindows::Communication::GuestNetwork.new(windows_machine.winrmshell)
+          guest_network = VagrantWindows::Communication::GuestNetwork.new(machine.communicate)
           if windows_machine.is_vmware?()
             @@logger.warn('Configuring secondary network adapters through VMware is not yet supported.')
             @@logger.warn('You will need to manually configure the network adapter.')

--- a/spec/vagrant-windows/guestnetwork_spec.rb
+++ b/spec/vagrant-windows/guestnetwork_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 
 describe VagrantWindows::Communication::GuestNetwork , :integration => true do
   
-  before(:all) do
+  before(:each) do
     port = (ENV['WINRM_PORT'] || 5985).to_i
+
+    @machine = stub()
     @shell = VagrantWindows::Communication::WinRMShell.new(
       "127.0.0.1", "vagrant", "vagrant", { port: port })
-    @guestnetwork = VagrantWindows::Communication::GuestNetwork.new(@shell)
+
+    @communicator = VagrantWindows::Communication::WinRMCommunicator.new(@machine)
+    @communicator.winrmshell = @shell
+    @guestnetwork = VagrantWindows::Communication::GuestNetwork.new(@communicator)
   end
   
   describe "wsman_version" do

--- a/spec/vagrant-windows/winrmshell_spec.rb
+++ b/spec/vagrant-windows/winrmshell_spec.rb
@@ -8,7 +8,7 @@ describe VagrantWindows::Communication::WinRMShell, :integration => true do
       "127.0.0.1", "vagrant", "vagrant", { port: port })
   end
   
-  describe "powershell" do
+  describe ".powershell" do
     it "should return exit code of 0" do
       expect(@shell.powershell("exit 0")[:exitcode]).to eq(0)
     end
@@ -26,13 +26,20 @@ describe VagrantWindows::Communication::WinRMShell, :integration => true do
     end
   end
   
-  describe "cmd" do
+  describe ".cmd" do
     it "should return stdout" do
       result = @shell.cmd("dir") do |type, line|
         expect(type).to eq(:stdout)
         expect(line.length).to be > 1  
       end
       expect(result[:exitcode]).to eq(0)
+    end
+  end
+
+  describe ".wql" do
+    it "should return query results in stdout" do
+      result = @shell.wql('SELECT * FROM Win32_NetworkAdapter WHERE MACAddress IS NOT NULL')
+      expect(result[:win32_network_adapter]).to_not be_empty
     end
   end
  


### PR DESCRIPTION
Adds support for WQL to Vagrant WinRM communicator
- Reduced duplication around WQL queries
- Added WQL specific spec
